### PR TITLE
fix(ci): use standard semver for MCP Registry version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Update server.json version
         if: steps.decide.outputs.should_build == 'true'
         run: |
-          VERSION="${{ steps.tags.outputs.full_tag }}"
+          VERSION="1.0.${{ github.run_number }}"
           jq --arg v "$VERSION" '.version = $v' server.json > server.tmp && mv server.tmp server.json
 
       - name: Authenticate to MCP Registry


### PR DESCRIPTION
## Summary
- MCP Registry version format changed from `2026.5.8-d8ab61a9e-9d7b0e9` to `1.0.{run_number}`
- The `-` in the old format was parsed as semver prerelease, preventing the Registry from correctly identifying the latest version
- `github.run_number` always increments, ensuring proper version ordering

## Test plan
- [ ] Verify CI passes
- [ ] After merge, check MCP Registry shows a clean `1.0.x` version marked as latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)