### PR TITLE
fix(ci): use version higher than existing Registry versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Update server.json version
         if: steps.decide.outputs.should_build == 'true'
         run: |
-          VERSION="1.0.${{ github.run_number }}"
+          VERSION="2026.${{ github.run_number }}.0"
           jq --arg v "$VERSION" '.version = $v' server.json > server.tmp && mv server.tmp server.json
 
       - name: Authenticate to MCP Registry


### PR DESCRIPTION
## Summary
- Previous fix used `1.0.x` which is lower than existing `2026.5.8-*` in semver ordering
- Changed to `2026.{run_number}.0` format which is always higher than `2026.5.8`
- This ensures the new version is correctly marked as `isLatest=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)