### PR TITLE
fix(ci): derive version year dynamically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Update server.json version
         if: steps.decide.outputs.should_build == 'true' && github.run_attempt == '1'
         run: |
-          VERSION="2026.${{ github.run_number }}.0"
+          VERSION="$(date -u +%Y).${{ github.run_number }}.0"
           jq --arg v "$VERSION" '.version = $v' server.json > server.tmp && mv server.tmp server.json
 
       - name: Authenticate to MCP Registry


### PR DESCRIPTION
## Summary
- Replace hardcoded `2026` with `$(date -u +%Y)` in MCP Registry version string
- Prevents versions published in 2027+ from sorting lower than existing 2026.x.y entries (PR #4 Copilot feedback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)