### PR TITLE
fix: correct Scorecard SHAs and address PR #10 Copilot feedback

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,6 +12,7 @@ jobs:
   analysis:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
       id-token: write
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,13 +21,13 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@05b42c624433fc40578a4093d71e3236ac4d23e7 # v2.4.1
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3
+        uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
         with:
           sarif_file: results.sarif

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -3,32 +3,33 @@
 # Usage: ./scripts/review-pr.sh <PR_NUMBER>
 #
 # - Network only during pip install, disabled for tests
-# - No access to host credentials
+# - No access to host credentials or .git directory
 # - Read-only source mount
 # - Disposable container (--rm)
 
-set -uo pipefail
+set -euo pipefail
 
 PR_NUMBER="${1:?Usage: $0 <PR_NUMBER>}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WORKDIR="/tmp/pr-review-$$"
-ORIGINAL_REF="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || git rev-parse HEAD)"
-EXIT_CODE=0
+
+# Capture original ref robustly (handles detached HEAD)
+ORIGINAL_REF="$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse HEAD)"
 
 cleanup() {
     echo "==> Cleaning up..."
     rm -rf "$WORKDIR"
-    git checkout "$ORIGINAL_REF" 2>/dev/null
+    git checkout "$ORIGINAL_REF" 2>/dev/null || true
 }
 trap cleanup EXIT
 
 echo "==> Fetching PR #$PR_NUMBER..."
 gh pr checkout "$PR_NUMBER" --detach
 
-echo "==> Copying source to temp directory..."
-mkdir -p "$WORKDIR"
+echo "==> Exporting source to temp directory (excluding .git)..."
+mkdir -p "$WORKDIR/src"
 git diff main...HEAD --stat
-cp -r "$REPO_ROOT" "$WORKDIR/src"
+rsync -a --exclude '.git' "$REPO_ROOT/" "$WORKDIR/src/"
 
 echo "==> Installing dependencies (network enabled)..."
 docker run --rm \
@@ -40,6 +41,7 @@ docker run --rm \
     pip install --quiet --target /deps "mcp[cli]" pytest pytest-anyio httpx pytest-cov pyyaml
 
 echo "==> Running tests (network disabled)..."
+EXIT_CODE=0
 docker run --rm \
     --network none \
     --memory 512m \


### PR DESCRIPTION
## Summary
- Fix pinned SHAs for ossf/scorecard-action and github/codeql-action (annotated tag → commit)
- Add contents:read to Scorecard job permissions
- review-pr.sh: restore set -euo pipefail, robust ref capture, rsync --exclude .git

## Test plan
- [ ] CI passes
- [ ] Scorecard workflow succeeds on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)