### PR TITLE
fix: Dependabot auto-merge, target branch, and review-pr.sh improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,18 +2,21 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
 
   - package-ecosystem: "docker"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,6 @@
 name: Dependabot Auto-Merge
 
-on: pull_request
+on: pull_request_target
 
 permissions:
   contents: write
@@ -8,17 +8,20 @@ permissions:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Approve PR
-        run: gh pr review "$PR_URL" --approve
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge
-        run: gh pr merge "$PR_URL" --auto --merge
+      - name: Approve and auto-merge patch/minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          gh pr review "$PR_URL" --approve
+          gh pr merge "$PR_URL" --auto --merge
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve PR
+        run: gh pr review "$PR_URL" --approve
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        run: gh pr merge "$PR_URL" --auto --merge
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -9,6 +9,10 @@
 
 set -euo pipefail
 
+for cmd in gh docker rsync; do
+    command -v "$cmd" >/dev/null 2>&1 || { echo "Error: $cmd is required but not found."; exit 1; }
+done
+
 PR_NUMBER="${1:?Usage: $0 <PR_NUMBER>}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WORKDIR="/tmp/pr-review-$$"

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -9,8 +9,8 @@
 
 set -euo pipefail
 
-for cmd in gh docker rsync; do
-    command -v "$cmd" >/dev/null 2>&1 || { echo "Error: $cmd is required but not found."; exit 1; }
+for cmd in git gh docker rsync; do
+    command -v "$cmd" >/dev/null 2>&1 || { echo "Error: $cmd is required but not found." >&2; exit 1; }
 done
 
 PR_NUMBER="${1:?Usage: $0 <PR_NUMBER>}"


### PR DESCRIPTION
## Summary
- Add Dependabot auto-merge workflow (pull_request_target, patch/minor only)
- Set Dependabot target branch to `dev`
- review-pr.sh: add `git` to dependency check, redirect errors to stderr

## Test plan
- [ ] CI + Copilot review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)