### PR TITLE
fix(ci): Dependabot compatibility and auto-merge improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,6 @@ jobs:
   test:
     if: github.event_name == 'push' && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -135,16 +132,6 @@ jobs:
         uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2
         with:
           paths: test-results.xml
-
-      - name: Coverage report
-        if: always()
-        uses: py-cov-action/python-coverage-comment-action@53ff7553078bad69030786e486677315346c2dd2 # v3
-        with:
-          GITHUB_TOKEN: ${{ github.token }}
-          MINIMUM_GREEN: 80
-          MINIMUM_ORANGE: 60
-          ANNOTATE_MISSING_LINES: false
-          COMMENT_ARTIFACT_NAME: ""
 
       - name: Upload test artifacts
         if: always()

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,12 +13,14 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Approve and auto-merge patch/minor updates
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: |
           gh pr review "$PR_URL" --approve
           gh pr merge "$PR_URL" --auto --merge

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,7 +21,7 @@ jobs:
         if: >-
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.dependency-type == 'direct:production' && steps.metadata.outputs.update-type == 'security-update'
+          steps.metadata.outputs.update-type == 'security-update'
         run: |
           gh pr review "$PR_URL" --approve
           gh pr merge "$PR_URL" --auto --merge

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,10 +17,11 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Approve and auto-merge patch/minor updates
+      - name: Approve and auto-merge patch/minor/security updates
         if: >-
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.dependency-type == 'direct:production' && steps.metadata.outputs.update-type == 'security-update'
         run: |
           gh pr review "$PR_URL" --approve
           gh pr merge "$PR_URL" --auto --merge


### PR DESCRIPTION
## Summary
- Disable coverage PR comments to reduce notification noise
- Exempt Dependabot PRs from source CI check
- Pin `dependabot/fetch-metadata` to SHA
- Auto-merge patch, minor, and security updates (skip major)
- Delete stale `python-coverage-comment-action-data` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)