### PR TITLE
fix(plugin): remove invalid skills/agents fields from manifests

### DIFF
--- a/plugins/local/.claude-plugin/plugin.json
+++ b/plugins/local/.claude-plugin/plugin.json
@@ -7,7 +7,5 @@
   },
   "repository": "https://github.com/whw23/searxng-http-mcp",
   "license": "MIT",
-  "keywords": ["search", "searxng", "web-search", "mcp"],
-  "skills": "./skills/",
-  "agents": "./agents/"
+  "keywords": ["search", "searxng", "web-search", "mcp"]
 }

--- a/plugins/remote/.claude-plugin/plugin.json
+++ b/plugins/remote/.claude-plugin/plugin.json
@@ -7,7 +7,5 @@
   },
   "repository": "https://github.com/whw23/searxng-http-mcp",
   "license": "MIT",
-  "keywords": ["search", "searxng", "web-search", "mcp", "remote"],
-  "skills": "./skills/",
-  "agents": "./agents/"
+  "keywords": ["search", "searxng", "web-search", "mcp", "remote"]
 }


### PR DESCRIPTION
## Summary
- Removed `skills` and `agents` string fields from both plugin manifests (`local` and `remote`)
- These fields caused plugin installation validation errors (`agents: Invalid input`) because the schema expects array format, not strings
- Since `agents/` and `skills/` are default auto-discovery directories, explicit declaration is unnecessary

## Test plan
- [ ] Install `searxng-http-mcp-remote` plugin via Claude Code CLI — should succeed without validation errors
- [ ] Verify agents and skills are auto-discovered from default directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)