### PR TITLE
fix(ci): skip Copilot review for dev-to-main PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           for i in $(seq 1 20); do
             STATE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | last | .state // empty')
+              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]" and .commit_id == "'"$HEAD_SHA"'")] | last | .state // empty')
             if [ -n "$STATE" ]; then
               echo "Copilot review received (state: $STATE)."
               if [ "$STATE" = "CHANGES_REQUESTED" ]; then
@@ -140,6 +140,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
   # === Plugin consistency (push + pull_request) ===
   plugin-consistency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
 
   # === Copilot code review gate (pull_request only) ===
   copilot-review:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.base_ref != 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Wait for Copilot code review

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           for i in $(seq 1 20); do
             STATE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]" and .commit_id == "'"$HEAD_SHA"'")] | last | .state // empty')
+              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | last | .state // empty')
             if [ -n "$STATE" ]; then
               echo "Copilot review received (state: $STATE)."
               if [ "$STATE" = "CHANGES_REQUESTED" ]; then
@@ -140,7 +140,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
   # === Plugin consistency (push + pull_request) ===
   plugin-consistency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           for i in $(seq 1 20); do
             STATE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer")] | last | .state // empty')
+              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | last | .state // empty')
             if [ -n "$STATE" ]; then
               echo "Copilot review received (state: $STATE)."
               if [ "$STATE" = "CHANGES_REQUESTED" ]; then


### PR DESCRIPTION
## Summary
- Skip `copilot-review` job when PR targets main (i.e. dev → main)
- Code is already reviewed by Copilot during feature → dev PRs, so repeating it is redundant

## Test plan
- [ ] PR from feature branch to dev: `copilot-review` job should run
- [ ] PR from dev to main: `copilot-review` job should be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)