### PR TITLE
feat(ci): add Copilot review gate and skip for main PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           for i in $(seq 1 20); do
             STATE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | last | .state // empty')
+              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]" and .commit_id == "'"$HEAD_SHA"'")] | last | .state // empty')
             if [ -n "$STATE" ]; then
               echo "Copilot review received (state: $STATE)."
               if [ "$STATE" = "CHANGES_REQUESTED" ]; then
@@ -152,6 +152,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
   # === Plugin consistency (push + pull_request) ===
   plugin-consistency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           for i in $(seq 1 20); do
             STATE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]" and .commit_id == "'"$HEAD_SHA"'")] | last | .state // empty')
+              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | last | .state // empty')
             if [ -n "$STATE" ]; then
               echo "Copilot review received (state: $STATE)."
               if [ "$STATE" = "CHANGES_REQUESTED" ]; then
@@ -152,7 +152,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
   # === Plugin consistency (push + pull_request) ===
   plugin-consistency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
 
   # === Copilot code review gate (pull_request only) ===
   copilot-review:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.base_ref != 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Wait for Copilot code review

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,10 @@ Make sure:
 
 Fork PRs **cannot** modify files in the `.github/` directory (workflows, CI configs). If you need changes to CI, open an issue to discuss.
 
+### Copilot code review
+
+All PRs are automatically reviewed by GitHub Copilot. The `copilot-review` CI check waits for Copilot to finish its review before passing. If Copilot requests changes, review its suggestions before merging.
+
 ### Plugin consistency
 
 If your changes touch `plugins/local/` or `plugins/remote/`, the `skills/` and `agents/` directories must stay identical between the two. The `plugin-consistency` check enforces this.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Fork PRs **cannot** modify files in the `.github/` directory (workflows, CI conf
 
 ### Copilot code review
 
-All PRs are automatically reviewed by GitHub Copilot. The `copilot-review` CI check waits for Copilot to finish its review before passing. If Copilot requests changes, review its suggestions before merging.
+All PRs targeting `dev` are automatically reviewed by GitHub Copilot. The `copilot-review` CI check waits for Copilot to finish its review before passing. If Copilot requests changes, review its suggestions before merging. PRs from `dev` to `main` skip this check since the code has already been reviewed.
 
 ### Plugin consistency
 


### PR DESCRIPTION
## Summary
- Add `copilot-review` CI job that waits for Copilot code review before passing
- Skip Copilot review for dev→main PRs (already reviewed during feature→dev)
- Fix Copilot bot login to `copilot-pull-request-reviewer[bot]`
- Document Copilot review process in CONTRIBUTING.md

## Test plan
- [ ] PR to dev: `copilot-review` job runs and detects Copilot review
- [ ] PR to main: `copilot-review` job is skipped
- [ ] CONTRIBUTING.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)