### PR TITLE
fix(ci): pass pr-policy when push CI is skipped by paths-ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,11 @@ jobs:
       - name: Require CI to have passed in source repo
         if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
+          TOTAL=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$HEAD_SHA&event=push" --jq '.total_count')
+          if [ "$TOTAL" -eq 0 ]; then
+            echo "No push-triggered CI runs for this commit (likely skipped by paths-ignore). Passing."
+            exit 0
+          fi
           MAX_ATTEMPTS=12
           for i in $(seq 1 $MAX_ATTEMPTS); do
             RUNS=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$HEAD_SHA&status=success&event=push" --jq '.total_count')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           for i in $(seq 1 20); do
             STATE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer")] | last | .state // empty')
+              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | last | .state // empty')
             if [ -n "$STATE" ]; then
               echo "Copilot review received (state: $STATE)."
               if [ "$STATE" = "CHANGES_REQUESTED" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,16 @@ jobs:
       - name: Require CI to have passed in source repo
         if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
-          TOTAL=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$HEAD_SHA&event=push" --jq '.total_count')
-          if [ "$TOTAL" -eq 0 ]; then
-            echo "No push-triggered CI runs for this commit (likely skipped by paths-ignore). Passing."
-            exit 0
+          TOTAL=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$HEAD_SHA&event=push" --jq '.total_count // 0')
+          if [ "${TOTAL:-0}" -eq 0 ]; then
+            CHANGED=$(gh pr diff "$PR_NUMBER" --name-only --repo "$BASE_REPO")
+            NON_IGNORED=$(echo "$CHANGED" | grep -v -E '(^[^/]*\.md$|^docs/|^assets/|^LICENSE$)' || true)
+            if [ -z "$NON_IGNORED" ]; then
+              echo "No push CI runs and all changed files match paths-ignore. Passing."
+              exit 0
+            fi
+            echo "::error::No push-triggered CI run found but PR changes non-ignored files: $NON_IGNORED"
+            exit 1
           fi
           MAX_ATTEMPTS=12
           for i in $(seq 1 $MAX_ATTEMPTS); do
@@ -115,7 +121,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REPO: ${{ github.repository }}
 
   # === Copilot code review gate (pull_request only) ===
   copilot-review:


### PR DESCRIPTION
## Summary
- When a commit only changes files matched by `paths-ignore` (e.g. `*.md`), no push CI run is created
- pr-policy now detects this case (total push runs == 0) and passes immediately instead of polling 3 minutes then failing

## Test plan
- [ ] PR with only `.md` changes: pr-policy should pass immediately
- [ ] PR with code changes: pr-policy should still poll for push CI as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)