### PR TITLE
chore: merge dev into main — CI/CD improvements and security fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,7 @@ on:
   schedule:
     - cron: "17 3 * * *"
 
-permissions:
-  contents: read
-  packages: write
+permissions: read-all
 
 env:
   IMAGE_NAME: ghcr.io/whw23/searxng-http-mcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           for i in $(seq 1 20); do
             STATE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | last | .state // empty')
+              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]" and .commit_id == "'"$HEAD_SHA"'")] | last | .state // empty')
             if [ -n "$STATE" ]; then
               echo "Copilot review received (state: $STATE)."
               if [ "$STATE" = "CHANGES_REQUESTED" ]; then
@@ -152,6 +152,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
   # === Plugin consistency (push + pull_request) ===
   plugin-consistency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,11 @@ jobs:
       - name: Require CI to have passed in source repo
         if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
+          TOTAL=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$HEAD_SHA&event=push" --jq '.total_count')
+          if [ "$TOTAL" -eq 0 ]; then
+            echo "No push-triggered CI runs for this commit (likely skipped by paths-ignore). Passing."
+            exit 0
+          fi
           MAX_ATTEMPTS=12
           for i in $(seq 1 $MAX_ATTEMPTS); do
             RUNS=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$HEAD_SHA&status=success&event=push" --jq '.total_count')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           for i in $(seq 1 20); do
             STATE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer")] | last | .state // empty')
+              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | last | .state // empty')
             if [ -n "$STATE" ]; then
               echo "Copilot review received (state: $STATE)."
               if [ "$STATE" = "CHANGES_REQUESTED" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,12 @@ jobs:
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
+
+  # === Copilot code review gate (pull_request only) ===
+  copilot-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
       - name: Wait for Copilot code review
         run: |
           for i in $(seq 1 20); do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,30 @@ jobs:
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
+      - name: Wait for Copilot code review
+        run: |
+          for i in $(seq 1 20); do
+            STATE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer")] | last | .state // empty')
+            if [ -n "$STATE" ]; then
+              echo "Copilot review received (state: $STATE)."
+              if [ "$STATE" = "CHANGES_REQUESTED" ]; then
+                echo "::warning::Copilot requested changes — review before merging."
+              fi
+              exit 0
+            fi
+            if [ "$i" -eq 20 ]; then
+              echo "::warning::Copilot review not received after 5 minutes — proceeding without it."
+              exit 0
+            fi
+            echo "Waiting for Copilot review... (attempt $i/20)"
+            sleep 15
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
   # === Plugin consistency (push + pull_request) ===
   plugin-consistency:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,12 +83,19 @@ jobs:
       - name: Require CI to have passed in source repo
         if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
-          RUNS=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$HEAD_SHA&status=success&event=push" --jq '.total_count')
-          if [ "$RUNS" -eq 0 ]; then
-            echo "::error::No successful push-triggered CI run found in $HEAD_REPO for commit $HEAD_SHA. CI must pass before submitting a PR."
-            exit 1
-          fi
-          echo "Source repo CI passed ($RUNS successful run(s) found in $HEAD_REPO)."
+          for i in $(seq 1 12); do
+            RUNS=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$HEAD_SHA&status=success&event=push" --jq '.total_count')
+            if [ "$RUNS" -gt 0 ]; then
+              echo "Source repo CI passed ($RUNS successful run(s) found in $HEAD_REPO)."
+              exit 0
+            fi
+            if [ "$i" -eq 12 ]; then
+              echo "::error::No successful push-triggered CI run found in $HEAD_REPO for commit $HEAD_SHA after 3 minutes. CI must pass before submitting a PR."
+              exit 1
+            fi
+            echo "Waiting for push CI to complete... (attempt $i/12)"
+            sleep 15
+          done
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches-ignore: [main]
     paths-ignore:
       - "*.md"
       - "docs/**"
@@ -155,7 +156,7 @@ jobs:
 
   # === Tests (push only, exclude main — never runs external code on PRs) ===
   test:
-    if: github.event_name == 'push' && github.ref != 'refs/heads/main'
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,16 @@ jobs:
       - name: Require CI to have passed in source repo
         if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
-          TOTAL=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$HEAD_SHA&event=push" --jq '.total_count')
-          if [ "$TOTAL" -eq 0 ]; then
-            echo "No push-triggered CI runs for this commit (likely skipped by paths-ignore). Passing."
-            exit 0
+          TOTAL=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$HEAD_SHA&event=push" --jq '.total_count // 0')
+          if [ "${TOTAL:-0}" -eq 0 ]; then
+            CHANGED=$(gh pr diff "$PR_NUMBER" --name-only --repo "$BASE_REPO")
+            NON_IGNORED=$(echo "$CHANGED" | grep -v -E '(^[^/]*\.md$|^docs/|^assets/|^LICENSE$)' || true)
+            if [ -z "$NON_IGNORED" ]; then
+              echo "No push CI runs and all changed files match paths-ignore. Passing."
+              exit 0
+            fi
+            echo "::error::No push-triggered CI run found but PR changes non-ignored files: $NON_IGNORED"
+            exit 1
           fi
           MAX_ATTEMPTS=12
           for i in $(seq 1 $MAX_ATTEMPTS); do
@@ -115,7 +121,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REPO: ${{ github.repository }}
 
   # === Copilot code review gate (pull_request only) ===
   copilot-review:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,17 +83,26 @@ jobs:
       - name: Require CI to have passed in source repo
         if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
-          for i in $(seq 1 12); do
+          MAX_ATTEMPTS=12
+          for i in $(seq 1 $MAX_ATTEMPTS); do
             RUNS=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$HEAD_SHA&status=success&event=push" --jq '.total_count')
             if [ "$RUNS" -gt 0 ]; then
               echo "Source repo CI passed ($RUNS successful run(s) found in $HEAD_REPO)."
               exit 0
             fi
-            if [ "$i" -eq 12 ]; then
-              echo "::error::No successful push-triggered CI run found in $HEAD_REPO for commit $HEAD_SHA after 3 minutes. CI must pass before submitting a PR."
+            FAILED=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$HEAD_SHA&event=push" \
+              --jq '[.workflow_runs[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out")] | first | .conclusion // empty')
+            if [ -n "$FAILED" ]; then
+              URL=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$HEAD_SHA&event=push" \
+                --jq '[.workflow_runs[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out")] | first | .html_url')
+              echo "::error::Push-triggered CI run concluded with '$FAILED': $URL"
               exit 1
             fi
-            echo "Waiting for push CI to complete... (attempt $i/12)"
+            if [ "$i" -eq "$MAX_ATTEMPTS" ]; then
+              echo "::error::No successful push-triggered CI run found in $HEAD_REPO for commit $HEAD_SHA after $((MAX_ATTEMPTS * 15)) seconds."
+              exit 1
+            fi
+            echo "Waiting for push CI to complete... (attempt $i/$MAX_ATTEMPTS)"
             sleep 15
           done
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           for i in $(seq 1 20); do
             STATE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]" and .commit_id == "'"$HEAD_SHA"'")] | last | .state // empty')
+              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | last | .state // empty')
             if [ -n "$STATE" ]; then
               echo "Copilot review received (state: $STATE)."
               if [ "$STATE" = "CHANGES_REQUESTED" ]; then
@@ -152,7 +152,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
   # === Plugin consistency (push + pull_request) ===
   plugin-consistency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
 
   # === Copilot code review gate (pull_request only) ===
   copilot-review:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.base_ref != 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Wait for Copilot code review

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,14 +2,15 @@ name: Dependabot Auto-Merge
 
 on: pull_request_target
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   auto-merge:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Fetch Dependabot metadata
         id: metadata

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,10 @@ Make sure:
 
 Fork PRs **cannot** modify files in the `.github/` directory (workflows, CI configs). If you need changes to CI, open an issue to discuss.
 
+### Copilot code review
+
+All PRs are automatically reviewed by GitHub Copilot. The `copilot-review` CI check waits for Copilot to finish its review before passing. If Copilot requests changes, review its suggestions before merging.
+
 ### Plugin consistency
 
 If your changes touch `plugins/local/` or `plugins/remote/`, the `skills/` and `agents/` directories must stay identical between the two. The `plugin-consistency` check enforces this.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Fork PRs **cannot** modify files in the `.github/` directory (workflows, CI conf
 
 ### Copilot code review
 
-All PRs are automatically reviewed by GitHub Copilot. The `copilot-review` CI check waits for Copilot to finish its review before passing. If Copilot requests changes, review its suggestions before merging.
+All PRs targeting `dev` are automatically reviewed by GitHub Copilot. The `copilot-review` CI check waits for Copilot to finish its review before passing. If Copilot requests changes, review its suggestions before merging. PRs from `dev` to `main` skip this check since the code has already been reviewed.
 
 ### Plugin consistency
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/searxng/searxng:latest
+FROM ghcr.io/searxng/searxng:latest@sha256:b5d4892daf19736acdefc34a67bb06dd702638beb282e993aeb612e0953c2d54
 
 ENV PATH="/usr/local/searxng/.venv/bin:${PATH}"
 


### PR DESCRIPTION
## Summary
- Add push CI polling in pr-policy with fast-fail on failure
- Add independent Copilot code review gate (skip for dev→main PRs)
- Fix Copilot bot login matching (`[bot]` suffix)
- Skip CI push triggers on main branch (Build workflow handles main)
- Handle paths-ignore edge case in pr-policy (verify changed files)
- Address OpenSSF Scorecard findings (token permissions, Dockerfile pin)
- Document Copilot review process in CONTRIBUTING.md

## Test plan
- [x] PR #25 and #26 validated all CI changes on dev
- [x] Build and Publish triggers on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)