### PR TITLE
chore: merge dev into main — web-searcher agent improvements

### DIFF
--- a/plugins/local/agents/web-searcher.md
+++ b/plugins/local/agents/web-searcher.md
@@ -74,7 +74,7 @@ Only use `engines` when you need a specific source (e.g., `arxiv` for preprints,
 1. **Search in parallel** — launch multiple searches simultaneously in one response:
    - **Parallel categories**: always include `general` (Google/Baidu) alongside any specialized category
    - **Parallel keywords**: use different phrasings, synonyms, or translations of the same query
-   - Example: searching for emoji should fire `general` + "thinking emoji" AND `icons` + "thinking emoji" AND `general` + "思考 emoji" in parallel
+   - Example: searching for emoji should fire `general` + "thinking emoji" AND `icons` + "thinking emoji" AND `general` + "思考 emoji" AND `icons` + "思考 emoji" in parallel
 2. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
 3. **Deduplicate and merge** results from parallel searches before returning
 4. **Use `pages=2` or `pages=3`** for comprehensive research

--- a/plugins/local/agents/web-searcher.md
+++ b/plugins/local/agents/web-searcher.md
@@ -74,7 +74,8 @@ Only use `engines` when you need a specific source (e.g., `arxiv` for preprints,
 1. **Search in parallel** — launch multiple searches simultaneously in one response:
    - **Parallel categories**: always include `general` (Google/Baidu) alongside any specialized category
    - **Parallel keywords**: use different phrasings, synonyms, or translations of the same query
-   - Example: searching for emoji should fire `general` + "thinking emoji" AND `icons` + "thinking emoji" AND `general` + "思考 emoji" AND `icons` + "思考 emoji" in parallel
+   - Combine categories × keywords, but **cap at 4-6 parallel searches** to avoid excessive requests
+   - Prioritize the most promising combinations rather than exhaustive cross-product
 2. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
 3. **Deduplicate and merge** results from parallel searches before returning
 4. **Use `pages=2` or `pages=3`** for comprehensive research

--- a/plugins/local/agents/web-searcher.md
+++ b/plugins/local/agents/web-searcher.md
@@ -71,9 +71,12 @@ Only use `engines` when you need a specific source (e.g., `arxiv` for preprints,
 
 ### Search strategy
 
-1. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
-2. **Run multiple searches** with different queries and categories when the topic is multi-faceted
-3. **Try alternative keywords** if the first search yields poor results — rephrase, use synonyms, or translate
+1. **Search in parallel** — launch multiple searches simultaneously in one response:
+   - **Parallel categories**: always include `general` (Google/Baidu) alongside any specialized category
+   - **Parallel keywords**: use different phrasings, synonyms, or translations of the same query
+   - Example: searching for emoji should fire `general` + "thinking emoji" AND `icons` + "thinking emoji" AND `general` + "思考 emoji" in parallel
+2. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
+3. **Deduplicate and merge** results from parallel searches before returning
 4. **Use `pages=2` or `pages=3`** for comprehensive research
 5. **Set `language`** to match the query language
 6. **Use `time_range`** for time-sensitive topics (`day`, `week`, `month`)

--- a/plugins/local/agents/web-searcher.md
+++ b/plugins/local/agents/web-searcher.md
@@ -77,10 +77,11 @@ Only use `engines` when you need a specific source (e.g., `arxiv` for preprints,
    - Combine categories × keywords, but **cap at 4-6 parallel searches** to avoid excessive requests
    - Prioritize the most promising combinations rather than exhaustive cross-product
 2. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
-3. **Deduplicate and merge** results from parallel searches before returning
-4. **Use `pages=2` or `pages=3`** for comprehensive research
-5. **Set `language`** to match the query language
-6. **Use `time_range`** for time-sensitive topics (`day`, `week`, `month`)
+3. **Auto-retry on insufficient results** — if initial searches return few or irrelevant results, automatically run a follow-up round with rephrased keywords or broader/narrower categories instead of giving up
+4. **Deduplicate and diversify sources** — remove duplicate URLs from parallel searches and prioritize results from different domains over multiple hits from the same site
+5. **Use `pages=2` or `pages=3`** for comprehensive research
+6. **Set `language`** to match the query language
+7. **Use `time_range`** for time-sensitive topics (`day`, `week`, `month`)
 
 ## Output format
 

--- a/plugins/local/agents/web-searcher.md
+++ b/plugins/local/agents/web-searcher.md
@@ -41,19 +41,42 @@ main agent, not directly to the user.
 
 ## How to search
 
-Use `categories` as your primary filter. Only use `engines` when you need a specific source.
+### Category selection
+
+Always pick the most specific category. Never default to `general` when a better fit exists.
 
 | Intent | Category |
 |---|---|
-| Current events | `news` |
-| Academic papers | `science` or `scientific publications` |
-| Code, tech docs | `it` |
-| Package lookup | `packages` |
-| General knowledge | `general` (default) |
+| Current events, breaking news | `news` |
+| Academic papers, research | `science` or `scientific publications` |
+| Code, tech docs, programming | `it` |
+| Package lookup (npm, pip) | `packages` |
+| Code repositories | `repos` |
+| Q&A (Stack Overflow, etc.) | `q&a` |
+| Images, photos | `images` |
+| Videos | `videos` |
+| Music, audio | `music` |
+| Icons, emoji, symbols | `icons` |
+| Maps, locations | `map` |
+| Weather | `weather` |
+| Definitions, dictionaries | `dictionaries` or `define` |
+| Translation | `translate` |
+| Shopping, products | `shopping` |
+| Social media posts | `social media` |
+| Files, torrents | `files` |
+| Currency conversion | `currency` |
+| General knowledge | `general` |
 
-For ambiguous queries, use `autocomplete` first to discover better search terms.
-For comprehensive research, use `pages=2` or `pages=3`.
-Set `language` to match the query language.
+Only use `engines` when you need a specific source (e.g., `arxiv` for preprints, `github` for repos).
+
+### Search strategy
+
+1. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
+2. **Run multiple searches** with different queries and categories when the topic is multi-faceted
+3. **Try alternative keywords** if the first search yields poor results — rephrase, use synonyms, or translate
+4. **Use `pages=2` or `pages=3`** for comprehensive research
+5. **Set `language`** to match the query language
+6. **Use `time_range`** for time-sensitive topics (`day`, `week`, `month`)
 
 ## Output format
 

--- a/plugins/local/agents/web-searcher.md
+++ b/plugins/local/agents/web-searcher.md
@@ -43,7 +43,7 @@ main agent, not directly to the user.
 
 ### Category selection
 
-Always pick the most specific category. Never default to `general` when a better fit exists.
+Prefer the most specific category when one fits. Fall back to `general` when no specific category matches or when unsure.
 
 | Intent | Category |
 |---|---|
@@ -81,7 +81,7 @@ Only use `engines` when you need a specific source (e.g., `arxiv` for preprints,
 4. **Deduplicate and diversify sources** — remove duplicate URLs from parallel searches and prioritize results from different domains over multiple hits from the same site
 5. **Use `pages=2` or `pages=3`** for comprehensive research
 6. **Set `language`** to match the query language
-7. **Use `time_range`** for time-sensitive topics (`day`, `week`, `month`)
+7. **Use `time_range`** for time-sensitive topics (`day`, `week`, `month`, `year`)
 
 ## Output format
 

--- a/plugins/local/agents/web-searcher.md
+++ b/plugins/local/agents/web-searcher.md
@@ -43,7 +43,7 @@ main agent, not directly to the user.
 
 ### Category selection
 
-Always use `general` (Google/Baidu). Additionally pick the most specific category from the table below when one fits.
+Always use `general`. Additionally pick the most specific category from the table below when one fits.
 
 | Intent | Category |
 |---|---|
@@ -72,7 +72,7 @@ Only use `engines` when you need a specific source (e.g., `arxiv` for preprints,
 ### Search strategy
 
 1. **Search in parallel** — launch multiple searches simultaneously in one response:
-   - **Parallel categories**: always include `general` (Google/Baidu) alongside any specialized category
+   - **Parallel categories**: always include `general` alongside any specialized category
    - **Parallel keywords**: use different phrasings, synonyms, or translations of the same query
    - Combine categories × keywords, but **cap at 4-6 parallel searches** to avoid excessive requests
    - Prioritize the most promising combinations rather than exhaustive cross-product

--- a/plugins/local/agents/web-searcher.md
+++ b/plugins/local/agents/web-searcher.md
@@ -65,18 +65,17 @@ Always use `general`. Additionally pick the most specific category from the tabl
 | Social media posts | `social media` |
 | Files, torrents | `files` |
 | Currency conversion | `currency` |
-| General knowledge | `general` |
 
 Only use `engines` when you need a specific source (e.g., `arxiv` for preprints, `github` for repos).
 
 ### Search strategy
 
-1. **Search in parallel** — launch multiple searches simultaneously in one response:
+1. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
+2. **Search in parallel** — launch multiple searches simultaneously in one response:
    - **Parallel categories**: always include `general` alongside any specialized category
    - **Parallel keywords**: use different phrasings, synonyms, or translations of the same query
    - Combine categories × keywords, but **cap at 4-6 parallel searches** to avoid excessive requests
    - Prioritize the most promising combinations rather than exhaustive cross-product
-2. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
 3. **Auto-retry on insufficient results** — if initial searches return few or irrelevant results, automatically run a follow-up round with rephrased keywords or broader/narrower categories instead of giving up
 4. **Deduplicate and diversify sources** — remove duplicate URLs from parallel searches and prioritize results from different domains over multiple hits from the same site
 5. **Use `pages=2` or `pages=3`** for comprehensive research
@@ -101,7 +100,5 @@ Return your findings in this structure:
 
 - Be concise — the main agent will relay your findings to the user
 - Always include source URLs so the main agent can cite them
-- If results are insufficient, say so clearly rather than speculating
-- For multi-faceted questions, run multiple searches with different queries
-- Prefer recent results for time-sensitive topics (use `time_range=week` or `time_range=month`)
+- If results are still insufficient after retrying, say so clearly rather than speculating
 - Do not editorialize — report what the sources say

--- a/plugins/local/agents/web-searcher.md
+++ b/plugins/local/agents/web-searcher.md
@@ -43,7 +43,7 @@ main agent, not directly to the user.
 
 ### Category selection
 
-Prefer the most specific category when one fits. Fall back to `general` when no specific category matches or when unsure.
+Always use `general` (Google/Baidu). Additionally pick the most specific category from the table below when one fits.
 
 | Intent | Category |
 |---|---|

--- a/plugins/remote/agents/web-searcher.md
+++ b/plugins/remote/agents/web-searcher.md
@@ -74,7 +74,7 @@ Only use `engines` when you need a specific source (e.g., `arxiv` for preprints,
 1. **Search in parallel** — launch multiple searches simultaneously in one response:
    - **Parallel categories**: always include `general` (Google/Baidu) alongside any specialized category
    - **Parallel keywords**: use different phrasings, synonyms, or translations of the same query
-   - Example: searching for emoji should fire `general` + "thinking emoji" AND `icons` + "thinking emoji" AND `general` + "思考 emoji" in parallel
+   - Example: searching for emoji should fire `general` + "thinking emoji" AND `icons` + "thinking emoji" AND `general` + "思考 emoji" AND `icons` + "思考 emoji" in parallel
 2. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
 3. **Deduplicate and merge** results from parallel searches before returning
 4. **Use `pages=2` or `pages=3`** for comprehensive research

--- a/plugins/remote/agents/web-searcher.md
+++ b/plugins/remote/agents/web-searcher.md
@@ -74,7 +74,8 @@ Only use `engines` when you need a specific source (e.g., `arxiv` for preprints,
 1. **Search in parallel** — launch multiple searches simultaneously in one response:
    - **Parallel categories**: always include `general` (Google/Baidu) alongside any specialized category
    - **Parallel keywords**: use different phrasings, synonyms, or translations of the same query
-   - Example: searching for emoji should fire `general` + "thinking emoji" AND `icons` + "thinking emoji" AND `general` + "思考 emoji" AND `icons` + "思考 emoji" in parallel
+   - Combine categories × keywords, but **cap at 4-6 parallel searches** to avoid excessive requests
+   - Prioritize the most promising combinations rather than exhaustive cross-product
 2. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
 3. **Deduplicate and merge** results from parallel searches before returning
 4. **Use `pages=2` or `pages=3`** for comprehensive research

--- a/plugins/remote/agents/web-searcher.md
+++ b/plugins/remote/agents/web-searcher.md
@@ -71,9 +71,12 @@ Only use `engines` when you need a specific source (e.g., `arxiv` for preprints,
 
 ### Search strategy
 
-1. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
-2. **Run multiple searches** with different queries and categories when the topic is multi-faceted
-3. **Try alternative keywords** if the first search yields poor results — rephrase, use synonyms, or translate
+1. **Search in parallel** — launch multiple searches simultaneously in one response:
+   - **Parallel categories**: always include `general` (Google/Baidu) alongside any specialized category
+   - **Parallel keywords**: use different phrasings, synonyms, or translations of the same query
+   - Example: searching for emoji should fire `general` + "thinking emoji" AND `icons` + "thinking emoji" AND `general` + "思考 emoji" in parallel
+2. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
+3. **Deduplicate and merge** results from parallel searches before returning
 4. **Use `pages=2` or `pages=3`** for comprehensive research
 5. **Set `language`** to match the query language
 6. **Use `time_range`** for time-sensitive topics (`day`, `week`, `month`)

--- a/plugins/remote/agents/web-searcher.md
+++ b/plugins/remote/agents/web-searcher.md
@@ -77,10 +77,11 @@ Only use `engines` when you need a specific source (e.g., `arxiv` for preprints,
    - Combine categories × keywords, but **cap at 4-6 parallel searches** to avoid excessive requests
    - Prioritize the most promising combinations rather than exhaustive cross-product
 2. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
-3. **Deduplicate and merge** results from parallel searches before returning
-4. **Use `pages=2` or `pages=3`** for comprehensive research
-5. **Set `language`** to match the query language
-6. **Use `time_range`** for time-sensitive topics (`day`, `week`, `month`)
+3. **Auto-retry on insufficient results** — if initial searches return few or irrelevant results, automatically run a follow-up round with rephrased keywords or broader/narrower categories instead of giving up
+4. **Deduplicate and diversify sources** — remove duplicate URLs from parallel searches and prioritize results from different domains over multiple hits from the same site
+5. **Use `pages=2` or `pages=3`** for comprehensive research
+6. **Set `language`** to match the query language
+7. **Use `time_range`** for time-sensitive topics (`day`, `week`, `month`)
 
 ## Output format
 

--- a/plugins/remote/agents/web-searcher.md
+++ b/plugins/remote/agents/web-searcher.md
@@ -41,19 +41,42 @@ main agent, not directly to the user.
 
 ## How to search
 
-Use `categories` as your primary filter. Only use `engines` when you need a specific source.
+### Category selection
+
+Always pick the most specific category. Never default to `general` when a better fit exists.
 
 | Intent | Category |
 |---|---|
-| Current events | `news` |
-| Academic papers | `science` or `scientific publications` |
-| Code, tech docs | `it` |
-| Package lookup | `packages` |
-| General knowledge | `general` (default) |
+| Current events, breaking news | `news` |
+| Academic papers, research | `science` or `scientific publications` |
+| Code, tech docs, programming | `it` |
+| Package lookup (npm, pip) | `packages` |
+| Code repositories | `repos` |
+| Q&A (Stack Overflow, etc.) | `q&a` |
+| Images, photos | `images` |
+| Videos | `videos` |
+| Music, audio | `music` |
+| Icons, emoji, symbols | `icons` |
+| Maps, locations | `map` |
+| Weather | `weather` |
+| Definitions, dictionaries | `dictionaries` or `define` |
+| Translation | `translate` |
+| Shopping, products | `shopping` |
+| Social media posts | `social media` |
+| Files, torrents | `files` |
+| Currency conversion | `currency` |
+| General knowledge | `general` |
 
-For ambiguous queries, use `autocomplete` first to discover better search terms.
-For comprehensive research, use `pages=2` or `pages=3`.
-Set `language` to match the query language.
+Only use `engines` when you need a specific source (e.g., `arxiv` for preprints, `github` for repos).
+
+### Search strategy
+
+1. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
+2. **Run multiple searches** with different queries and categories when the topic is multi-faceted
+3. **Try alternative keywords** if the first search yields poor results — rephrase, use synonyms, or translate
+4. **Use `pages=2` or `pages=3`** for comprehensive research
+5. **Set `language`** to match the query language
+6. **Use `time_range`** for time-sensitive topics (`day`, `week`, `month`)
 
 ## Output format
 

--- a/plugins/remote/agents/web-searcher.md
+++ b/plugins/remote/agents/web-searcher.md
@@ -43,7 +43,7 @@ main agent, not directly to the user.
 
 ### Category selection
 
-Always pick the most specific category. Never default to `general` when a better fit exists.
+Prefer the most specific category when one fits. Fall back to `general` when no specific category matches or when unsure.
 
 | Intent | Category |
 |---|---|
@@ -81,7 +81,7 @@ Only use `engines` when you need a specific source (e.g., `arxiv` for preprints,
 4. **Deduplicate and diversify sources** — remove duplicate URLs from parallel searches and prioritize results from different domains over multiple hits from the same site
 5. **Use `pages=2` or `pages=3`** for comprehensive research
 6. **Set `language`** to match the query language
-7. **Use `time_range`** for time-sensitive topics (`day`, `week`, `month`)
+7. **Use `time_range`** for time-sensitive topics (`day`, `week`, `month`, `year`)
 
 ## Output format
 

--- a/plugins/remote/agents/web-searcher.md
+++ b/plugins/remote/agents/web-searcher.md
@@ -43,7 +43,7 @@ main agent, not directly to the user.
 
 ### Category selection
 
-Always use `general` (Google/Baidu). Additionally pick the most specific category from the table below when one fits.
+Always use `general`. Additionally pick the most specific category from the table below when one fits.
 
 | Intent | Category |
 |---|---|
@@ -72,7 +72,7 @@ Only use `engines` when you need a specific source (e.g., `arxiv` for preprints,
 ### Search strategy
 
 1. **Search in parallel** — launch multiple searches simultaneously in one response:
-   - **Parallel categories**: always include `general` (Google/Baidu) alongside any specialized category
+   - **Parallel categories**: always include `general` alongside any specialized category
    - **Parallel keywords**: use different phrasings, synonyms, or translations of the same query
    - Combine categories × keywords, but **cap at 4-6 parallel searches** to avoid excessive requests
    - Prioritize the most promising combinations rather than exhaustive cross-product

--- a/plugins/remote/agents/web-searcher.md
+++ b/plugins/remote/agents/web-searcher.md
@@ -65,18 +65,17 @@ Always use `general`. Additionally pick the most specific category from the tabl
 | Social media posts | `social media` |
 | Files, torrents | `files` |
 | Currency conversion | `currency` |
-| General knowledge | `general` |
 
 Only use `engines` when you need a specific source (e.g., `arxiv` for preprints, `github` for repos).
 
 ### Search strategy
 
-1. **Search in parallel** — launch multiple searches simultaneously in one response:
+1. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
+2. **Search in parallel** — launch multiple searches simultaneously in one response:
    - **Parallel categories**: always include `general` alongside any specialized category
    - **Parallel keywords**: use different phrasings, synonyms, or translations of the same query
    - Combine categories × keywords, but **cap at 4-6 parallel searches** to avoid excessive requests
    - Prioritize the most promising combinations rather than exhaustive cross-product
-2. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
 3. **Auto-retry on insufficient results** — if initial searches return few or irrelevant results, automatically run a follow-up round with rephrased keywords or broader/narrower categories instead of giving up
 4. **Deduplicate and diversify sources** — remove duplicate URLs from parallel searches and prioritize results from different domains over multiple hits from the same site
 5. **Use `pages=2` or `pages=3`** for comprehensive research
@@ -101,7 +100,5 @@ Return your findings in this structure:
 
 - Be concise — the main agent will relay your findings to the user
 - Always include source URLs so the main agent can cite them
-- If results are insufficient, say so clearly rather than speculating
-- For multi-faceted questions, run multiple searches with different queries
-- Prefer recent results for time-sensitive topics (use `time_range=week` or `time_range=month`)
+- If results are still insufficient after retrying, say so clearly rather than speculating
 - Do not editorialize — report what the sources say

--- a/plugins/remote/agents/web-searcher.md
+++ b/plugins/remote/agents/web-searcher.md
@@ -43,7 +43,7 @@ main agent, not directly to the user.
 
 ### Category selection
 
-Prefer the most specific category when one fits. Fall back to `general` when no specific category matches or when unsure.
+Always use `general` (Google/Baidu). Additionally pick the most specific category from the table below when one fits.
 
 | Intent | Category |
 |---|---|


### PR DESCRIPTION
## Summary
- Expand web-searcher category table from 5 to 19 specific categories
- Add parallel search strategy: general + specialized categories × multiple keywords (capped at 4-6)
- Add auto-retry on insufficient results and source diversity
- Fix Copilot review feedback: soften category guidance, add `year` to time_range

## Test plan
- [x] PR #28 validated all changes on dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)