### PR TITLE
fix: address unresolved Copilot review feedback from PRs #27, #29, #31

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
         if: steps.decide.outputs.should_build == 'true'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ${{ env.IMAGE_NAME }}:latest
+          image-ref: ${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,24 +92,29 @@ jobs:
             COMMIT_FILES=$(gh api "repos/$HEAD_REPO/commits/$HEAD_SHA" --jq '[.files[].filename] | join("\n")')
             NON_IGNORED=$(echo "$COMMIT_FILES" | grep -v -E '(^[^/]*\.md$|^docs/|^assets/|^LICENSE$)' || true)
             if [ -z "$NON_IGNORED" ]; then
-              # Head commit is docs-only. Verify that the PR's code-changing commits
-              # have a successful push CI run by walking earlier commits.
+              # Head commit is docs-only. Find the latest code-changing commit in the
+              # PR and require a successful push CI run for it.
               PR_COMMITS=$(gh api "repos/$BASE_REPO/pulls/$PR_NUMBER/commits" --jq '.[].sha')
-              FOUND_CI=false
+              LATEST_CODE_SHA=""
               for sha in $PR_COMMITS; do
-                RUNS=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$sha&status=success&event=push" --jq '.total_count // 0')
-                if [ "${RUNS:-0}" -gt 0 ]; then
-                  echo "Head commit is docs-only; found passing push CI on earlier commit $sha."
-                  FOUND_CI=true
-                  break
+                C_FILES=$(gh api "repos/$HEAD_REPO/commits/$sha" --jq '[.files[].filename] | join("\n")')
+                C_NON_IGNORED=$(echo "$C_FILES" | grep -v -E '(^[^/]*\.md$|^docs/|^assets/|^LICENSE$)' || true)
+                if [ -n "$C_NON_IGNORED" ]; then
+                  LATEST_CODE_SHA="$sha"
                 fi
               done
-              if [ "$FOUND_CI" = "true" ]; then
+              if [ -z "$LATEST_CODE_SHA" ]; then
+                echo "All PR commits are docs-only. Passing."
                 exit 0
               fi
-              # No code-changing commits in this PR, or all changes are docs-only
-              echo "Head commit only changes ignored files and push CI was skipped. Passing."
-              exit 0
+              # Found a code-changing commit — require passing CI for it
+              RUNS=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$LATEST_CODE_SHA&status=success&event=push" --jq '.total_count // 0')
+              if [ "${RUNS:-0}" -gt 0 ]; then
+                echo "Head commit is docs-only; latest code commit $LATEST_CODE_SHA has passing push CI."
+                exit 0
+              fi
+              echo "::error::Head commit is docs-only but latest code-changing commit $LATEST_CODE_SHA has no successful push CI run."
+              exit 1
             fi
             echo "::error::No push-triggered CI run found but head commit changes non-ignored files: $NON_IGNORED"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,22 @@ jobs:
             COMMIT_FILES=$(gh api "repos/$HEAD_REPO/commits/$HEAD_SHA" --jq '[.files[].filename] | join("\n")')
             NON_IGNORED=$(echo "$COMMIT_FILES" | grep -v -E '(^[^/]*\.md$|^docs/|^assets/|^LICENSE$)' || true)
             if [ -z "$NON_IGNORED" ]; then
+              # Head commit is docs-only. Verify that the PR's code-changing commits
+              # have a successful push CI run by walking earlier commits.
+              PR_COMMITS=$(gh api "repos/$BASE_REPO/pulls/$PR_NUMBER/commits" --jq '.[].sha')
+              FOUND_CI=false
+              for sha in $PR_COMMITS; do
+                RUNS=$(gh api "repos/$HEAD_REPO/actions/runs?head_sha=$sha&status=success&event=push" --jq '.total_count // 0')
+                if [ "${RUNS:-0}" -gt 0 ]; then
+                  echo "Head commit is docs-only; found passing push CI on earlier commit $sha."
+                  FOUND_CI=true
+                  break
+                fi
+              done
+              if [ "$FOUND_CI" = "true" ]; then
+                exit 0
+              fi
+              # No code-changing commits in this PR, or all changes are docs-only
               echo "Head commit only changes ignored files and push CI was skipped. Passing."
               exit 0
             fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Fork PRs **cannot** modify files in the `.github/` directory (workflows, CI conf
 
 ### Copilot code review
 
-PRs targeting `dev` are automatically reviewed by GitHub Copilot (PRs from `dev` to `main` skip this check since the code has already been reviewed). The `copilot-review` CI check waits for Copilot to finish its review before passing. If Copilot requests changes, fix the issues and push new commits to the **same PR branch** — do not open a separate PR. After pushing fixes, mark the resolved review threads as **Resolved** on GitHub.
+PRs targeting `dev` are automatically reviewed by GitHub Copilot (PRs from `dev` to `main` skip this check since the code has already been reviewed). The `copilot-review` CI check waits up to 5 minutes for Copilot to finish its review; if no review is received within that window, the check passes with a warning. If Copilot requests changes, fix the issues and push new commits to the **same PR branch** — do not open a separate PR. After pushing fixes, mark the resolved review threads as **Resolved** on GitHub.
 
 ### Plugin consistency
 
@@ -91,7 +91,7 @@ pytest tests/ -v
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/):
 
-```
+```text
 feat(tools): add new search parameter
 fix(proxy): handle timeout errors
 docs: update README examples

--- a/plugins/local/agents/web-searcher.md
+++ b/plugins/local/agents/web-searcher.md
@@ -43,7 +43,7 @@ main agent, not directly to the user.
 
 ### Category selection
 
-Always use `general`. Additionally pick the most specific category from the table below when one fits.
+Use `general` as the default. When a more specific category fits, prefer it — combine with `general` for broad research, or use it alone for targeted searches (e.g., `images`, `science`). Call `engine_info` to confirm available categories if unsure.
 
 | Intent | Category |
 |---|---|

--- a/plugins/remote/agents/web-searcher.md
+++ b/plugins/remote/agents/web-searcher.md
@@ -43,7 +43,7 @@ main agent, not directly to the user.
 
 ### Category selection
 
-Always use `general`. Additionally pick the most specific category from the table below when one fits.
+Use `general` as the default. When a more specific category fits, prefer it — combine with `general` for broad research, or use it alone for targeted searches (e.g., `images`, `science`). Call `engine_info` to confirm available categories if unsure.
 
 | Intent | Category |
 |---|---|


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md**: clarify copilot-review timeout behavior — passes with warning after 5 minutes if no review received (PR #27)
- **Agent prompt**: align category guidance with SKILL.md — `general` as default, specific categories for targeted searches, suggest `engine_info` to confirm available categories (PR #29)
- **build.yml**: Trivy scans exact image digest instead of mutable `:latest` tag (PR #31)
- **ci.yml**: when head commit is docs-only, walk earlier PR commits to verify code-changing commits have passing push CI (PR #31)
- Fix MD040 lint warning in CONTRIBUTING.md

## Test plan

- [x] All 50 tests pass
- [x] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)