### PR TITLE
chore: merge dev into main — Copilot review round 2 fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
             if [ -z "$NON_IGNORED" ]; then
               # Head commit is docs-only. Find the latest code-changing commit in the
               # PR and require a successful push CI run for it.
-              PR_COMMITS=$(gh api "repos/$BASE_REPO/pulls/$PR_NUMBER/commits" --jq '.[].sha')
+              PR_COMMITS=$(gh api --paginate "repos/$BASE_REPO/pulls/$PR_NUMBER/commits?per_page=100" --jq '.[].sha')
               LATEST_CODE_SHA=""
               for sha in $PR_COMMITS; do
                 C_FILES=$(gh api "repos/$HEAD_REPO/commits/$sha" --jq '[.files[].filename] | join("\n")')

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Fork PRs **cannot** modify files in the `.github/` directory (workflows, CI conf
 
 ### Copilot code review
 
-PRs targeting `dev` are automatically reviewed by GitHub Copilot (PRs from `dev` to `main` skip this check since the code has already been reviewed). The `copilot-review` CI check waits up to 5 minutes for Copilot to finish its review; if no review is received within that window, the check passes with a warning. If Copilot requests changes, fix the issues and push new commits to the **same PR branch** — do not open a separate PR. After pushing fixes, mark the resolved review threads as **Resolved** on GitHub.
+All PRs are automatically reviewed by GitHub Copilot. For PRs targeting `dev`, the `copilot-review` CI check waits up to 5 minutes for Copilot to finish; if no review is received within that window, the check passes with a warning. PRs from `dev` to `main` skip this CI gate (the code was already reviewed on `dev`), but Copilot will still post a review. If Copilot requests changes, fix the issues and push new commits to the **same PR branch** — do not open a separate PR. After pushing fixes, mark the resolved review threads as **Resolved** on GitHub.
 
 ### Plugin consistency
 

--- a/plugins/local/agents/web-searcher.md
+++ b/plugins/local/agents/web-searcher.md
@@ -72,7 +72,7 @@ Only use `engines` when you need a specific source (e.g., `arxiv` for preprints,
 
 1. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
 2. **Search in parallel** — launch multiple searches simultaneously in one response:
-   - **Parallel categories**: always include `general` alongside any specialized category
+   - **Parallel categories**: include `general` alongside specialized categories for broad research; for targeted searches (e.g., `images`, `science`), the specialized category alone is fine
    - **Parallel keywords**: use different phrasings, synonyms, or translations of the same query
    - Combine categories × keywords, but **cap at 4-6 parallel searches** to avoid excessive requests
    - Prioritize the most promising combinations rather than exhaustive cross-product

--- a/plugins/remote/agents/web-searcher.md
+++ b/plugins/remote/agents/web-searcher.md
@@ -72,7 +72,7 @@ Only use `engines` when you need a specific source (e.g., `arxiv` for preprints,
 
 1. **Use `autocomplete` first** for ambiguous or broad queries to discover better search terms
 2. **Search in parallel** — launch multiple searches simultaneously in one response:
-   - **Parallel categories**: always include `general` alongside any specialized category
+   - **Parallel categories**: include `general` alongside specialized categories for broad research; for targeted searches (e.g., `images`, `science`), the specialized category alone is fine
    - **Parallel keywords**: use different phrasings, synonyms, or translations of the same query
    - Combine categories × keywords, but **cap at 4-6 parallel searches** to avoid excessive requests
    - Prioritize the most promising combinations rather than exhaustive cross-product


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md**: clarify Copilot reviews all PRs, CI gate is dev-only
- **Agent**: reconcile conflicting category guidance — specialized category alone for targeted searches, `general` alongside for broad research
- **ci.yml**: use `--paginate` for PR commits API to handle PRs with >30 commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)