### PR TITLE
chore: merge dev into main — CI paths-ignore fix and workflow docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,8 @@ name: CI
 on:
   push:
     branches-ignore: [main]
-    paths-ignore:
-      - "*.md"
-      - "docs/**"
-      - "assets/**"
-      - "LICENSE"
   pull_request:
     branches: [dev, main]
-    paths-ignore:
-      - "*.md"
-      - "docs/**"
-      - "assets/**"
-      - "LICENSE"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -190,24 +180,41 @@ jobs:
           diff -r plugins/local/agents plugins/remote/agents || { echo "::error::Agents differ between local and remote plugins"; exit 1; }
           echo "Plugins are consistent."
 
-  # === Tests (push only, exclude main — never runs external code on PRs) ===
+  # === Tests (push only, skip for docs-only changes) ===
   test:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 2
+
+      - name: Check for code changes
+        id: changes
+        run: |
+          FILES=$(git diff --name-only HEAD~1)
+          NON_DOCS=$(echo "$FILES" | grep -v -E '(^[^/]*\.md$|^docs/|^assets/|^LICENSE$)' || true)
+          if [ -z "$NON_DOCS" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Only docs changed, skipping tests."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Python
+        if: steps.changes.outputs.skip != 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
           cache: pip
 
       - name: Install dependencies
+        if: steps.changes.outputs.skip != 'true'
         run: pip install "mcp[cli]" pytest pytest-anyio httpx pytest-cov pyyaml
 
       - name: Run tests
+        if: steps.changes.outputs.skip != 'true'
         run: pytest tests/ -v --tb=short --junitxml=test-results.xml --cov=mcp_server --cov-report=term-missing --cov-report=xml:coverage.xml --cov-fail-under=80
 
       - name: Test report summary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,10 @@ graph LR
     H -->|Changes requested| C
     H -->|Approved| I[Merge to dev]
     I --> J[Maintainer PRs dev → main]
-    J --> K[Build & Publish]
+    J --> K{Copilot review}
+    K -->|Changes requested| C
+    K -->|Passed| L[Merge to main]
+    L --> M[Build & Publish]
 ```
 
 1. **Fork** this repository
@@ -28,7 +31,8 @@ graph LR
 5. **Wait for CI to pass** in your fork
 6. Open a **Pull Request to the `dev` branch** (not `main`)
 7. **Wait for Copilot code review** — address any feedback if changes are requested
-8. A maintainer will review and merge
+8. A maintainer will review and merge to `dev`
+9. Maintainer PRs `dev` → `main` — Copilot reviews again, any new feedback is addressed before merge
 
 ## Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,8 @@ graph LR
     H -->|Changes requested| C
     H -->|Approved| I[Merge to dev]
     I --> J[Maintainer PRs dev → main]
-    J --> K{Copilot review}
-    K -->|Changes requested| C
-    K -->|Passed| L[Merge to main]
+    J --> K[Copilot review non-blocking]
+    K --> L[Merge to main]
     L --> M[Build & Publish]
 ```
 
@@ -32,7 +31,7 @@ graph LR
 6. Open a **Pull Request to the `dev` branch** (not `main`)
 7. **Wait for Copilot code review** — address any feedback if changes are requested
 8. A maintainer will review and merge to `dev`
-9. Maintainer PRs `dev` → `main` — Copilot reviews again, any new feedback is addressed before merge
+9. Maintainer PRs `dev` → `main` — Copilot may post a non-blocking review; maintainer addresses feedback at their discretion
 
 ## Rules
 


### PR DESCRIPTION
## Summary

- **ci.yml**: remove top-level `paths-ignore` to ensure required checks always report status for docs-only PRs; move path filtering to job-level step conditions
- **CONTRIBUTING.md**: update workflow diagram and steps to show dev→main Copilot review as non-blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)