### PR TITLE
Fix README links and add transport integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@
 </p>
 
 <p>
-  <a href="#quick-start">Quick Start</a> ·
-  <a href="#features">Features</a> ·
-  <a href="#architecture">Architecture</a> ·
-  <a href="#comparison-with-alternatives">Comparison</a> ·
-  <a href="#usage">Usage</a> ·
-  <a href="#mcp-tools-reference">MCP Tools</a> ·
-  <a href="#client-configuration">Client Config</a> ·
-  <a href="#claude-code-plugin">Plugin</a> ·
-  <a href="#contributing">Contributing</a>
+  <a href="#-quick-start">Quick Start</a> ·
+  <a href="#-features">Features</a> ·
+  <a href="#-architecture">Architecture</a> ·
+  <a href="#-comparison-with-alternatives">Comparison</a> ·
+  <a href="#-usage">Usage</a> ·
+  <a href="#-mcp-tools-reference">MCP Tools</a> ·
+  <a href="#-client-configuration">Client Config</a> ·
+  <a href="#-claude-code-plugin">Plugin</a> ·
+  <a href="#-contributing">Contributing</a>
 </p>
 
 </div>
@@ -632,10 +632,12 @@ docker run -d --name searxng-mcp --restart unless-stopped \
 
 ## 🤝 Contributing
 
-1. 🍴 Fork the repository
+See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the full workflow, CI requirements, and development setup.
+
+1. 🍴 Fork the repository and enable GitHub Actions in your fork
 2. 🌿 Create a feature branch from `dev`
 3. ✍️ Make your changes
-4. ✅ Run tests: `pytest tests/ -v`
+4. ✅ Run tests: `pytest tests/ -v` — CI must pass in your fork before opening a PR
 5. 📬 Submit a PR to `dev`
 
 Development happens on the `dev` branch. Merges to `main` trigger image builds.
@@ -644,4 +646,4 @@ Development happens on the `dev` branch. Merges to `main` trigger image builds.
 
 [MIT](LICENSE) — MCP server code.
 
-SearXNG itself is licensed under [AGPL-3.0-or-later](https://github.com/searxng/searxng/blob/master/LICENSE).
+[SearXNG](https://github.com/searxng/searxng) itself is licensed under [AGPL-3.0-or-later](https://github.com/searxng/searxng/blob/master/LICENSE).

--- a/tests/stdio_server_mock.py
+++ b/tests/stdio_server_mock.py
@@ -1,0 +1,67 @@
+"""Mock MCP stdio server for integration tests.
+
+Patches httpx so the MCP tools work without a real SearXNG instance.
+Launched as a subprocess by test_stdio.py.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+
+MOCK_SEARCH_RESPONSE = {
+    "results": [
+        {
+            "title": "Test Result",
+            "url": "https://example.com",
+            "content": "Test content from mock.",
+            "engines": ["google"],
+            "score": 5.0,
+            "category": "general",
+        }
+    ],
+    "answers": [],
+    "suggestions": ["test suggestion"],
+    "corrections": [],
+    "infoboxes": [],
+    "unresponsive_engines": [],
+}
+
+MOCK_AUTOCOMPLETE_RESPONSE = ["test query", "test automation", "testing"]
+
+MOCK_CONFIG_RESPONSE = {
+    "categories": ["general", "images", "news"],
+    "engines": [
+        {"name": "google", "enabled": True, "categories": ["general"]},
+        {"name": "bing", "enabled": True, "categories": ["general", "images"]},
+        {"name": "google news", "enabled": True, "categories": ["news"]},
+    ],
+}
+
+
+def _mock_response(data: dict | list, status_code: int = 200) -> httpx.Response:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = data
+    return resp
+
+
+async def _mock_get(url: str, **kwargs) -> httpx.Response:
+    if "/search" in url:
+        return _mock_response(MOCK_SEARCH_RESPONSE)
+    if "/autocomplete" in url:
+        return _mock_response(MOCK_AUTOCOMPLETE_RESPONSE)
+    if "/config" in url:
+        return _mock_response(MOCK_CONFIG_RESPONSE)
+    return _mock_response({"error": "not found"}, 404)
+
+
+if __name__ == "__main__":
+    import mcp_server.tools as tools_mod
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get = _mock_get
+    mock_client.is_closed = False
+    tools_mod._http_client = mock_client
+
+    tools_mod.mcp.run(transport="stdio")

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,163 @@
+"""Integration tests for MCP HTTP transport mode."""
+
+import json
+import socket
+import threading
+import time
+
+import pytest
+import uvicorn
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+
+MOCK_SEARCH_RESPONSE = {
+    "results": [
+        {
+            "title": "HTTP Test Result",
+            "url": "https://example.com",
+            "content": "Test content from HTTP mock.",
+            "engines": ["google"],
+            "score": 5.0,
+            "category": "general",
+        }
+    ],
+    "answers": [],
+    "suggestions": ["http suggestion"],
+    "corrections": [],
+    "infoboxes": [],
+    "unresponsive_engines": [],
+}
+
+MOCK_AUTOCOMPLETE_RESPONSE = ["http query", "http test"]
+
+MOCK_CONFIG_RESPONSE = {
+    "categories": ["general", "images", "news"],
+    "engines": [
+        {"name": "google", "enabled": True, "categories": ["general"]},
+        {"name": "bing", "enabled": True, "categories": ["general", "images"]},
+    ],
+}
+
+
+def _mock_response(data):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.json.return_value = data
+    return resp
+
+
+async def _mock_get(url, **kwargs):
+    if "/search" in str(url):
+        return _mock_response(MOCK_SEARCH_RESPONSE)
+    if "/autocomplete" in str(url):
+        return _mock_response(MOCK_AUTOCOMPLETE_RESPONSE)
+    if "/config" in str(url):
+        return _mock_response(MOCK_CONFIG_RESPONSE)
+    return _mock_response({"error": "not found"})
+
+
+def _find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def server_url():
+    """Start a real HTTP MCP server with mocked SearXNG and return its URL."""
+    import mcp_server.tools as tools_mod
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get = _mock_get
+    mock_client.is_closed = False
+    tools_mod._http_client = mock_client
+
+    port = _find_free_port()
+
+    with patch.dict("os.environ", {"API_KEY": "", "SEARXNG_URL": "http://mock:8080"}):
+        from mcp_server.app import create_app
+        app = create_app()
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if server.started:
+            break
+        time.sleep(0.1)
+    else:
+        raise RuntimeError("Server did not start in time")
+
+    yield f"http://127.0.0.1:{port}/mcp/"
+
+    server.should_exit = True
+    thread.join(timeout=5)
+
+    tools_mod._http_client = None
+    tools_mod._cache.clear()
+    tools_mod._engine_info_cache = None
+    tools_mod._engine_info_cache_ts = 0
+
+
+@pytest.fixture
+async def session(server_url):
+    """Connect to the HTTP MCP server and return a session."""
+    async with streamable_http_client(server_url) as (read_stream, write_stream, _):
+        async with ClientSession(read_stream, write_stream) as s:
+            await s.initialize()
+            yield s
+
+
+@pytest.mark.anyio
+async def test_list_tools(session):
+    result = await session.list_tools()
+    tool_names = {t.name for t in result.tools}
+    assert tool_names == {"search", "autocomplete", "engine_info"}
+
+
+@pytest.mark.anyio
+async def test_search(session):
+    result = await session.call_tool("search", {"query": "test"})
+    assert not result.isError
+    data = json.loads(result.content[0].text)
+    assert "results" in data
+    assert len(data["results"]) > 0
+    assert data["results"][0]["title"] == "HTTP Test Result"
+
+
+@pytest.mark.anyio
+async def test_search_full_format(session):
+    result = await session.call_tool(
+        "search", {"query": "test", "format": "full", "max_results": 1}
+    )
+    assert not result.isError
+    data = json.loads(result.content[0].text)
+    assert data["results"][0].get("engines") is not None
+
+
+@pytest.mark.anyio
+async def test_autocomplete(session):
+    result = await session.call_tool("autocomplete", {"query": "http"})
+    assert not result.isError
+    data = json.loads(result.content[0].text)
+    assert isinstance(data, list)
+    assert len(data) > 0
+
+
+@pytest.mark.anyio
+async def test_engine_info(session):
+    result = await session.call_tool("engine_info", {})
+    assert not result.isError
+    data = json.loads(result.content[0].text)
+    assert "categories" in data
+    assert "engines" in data
+    assert "category_engines" in data
+    assert "general" in data["categories"]

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -57,7 +57,9 @@ async def _mock_get(url, **kwargs):
         return _mock_response(MOCK_AUTOCOMPLETE_RESPONSE)
     if "/config" in str(url):
         return _mock_response(MOCK_CONFIG_RESPONSE)
-    return _mock_response({"error": "not found"})
+    resp = _mock_response({"error": "not found"})
+    resp.status_code = 404
+    return resp
 
 
 def _find_free_port():
@@ -100,6 +102,7 @@ def server_url():
 
     server.should_exit = True
     thread.join(timeout=5)
+    assert not thread.is_alive(), "Server thread did not shut down cleanly"
 
     tools_mod._http_client = None
     tools_mod._cache.clear()

--- a/tests/test_stdio.py
+++ b/tests/test_stdio.py
@@ -1,0 +1,72 @@
+"""Integration tests for MCP stdio transport mode."""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from mcp.client.session import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+MOCK_SERVER = str(Path(__file__).parent / "stdio_server_mock.py")
+
+
+@pytest.fixture
+async def session():
+    """Start the mock MCP server in stdio mode and return a connected session."""
+    env = {**os.environ, "PYTHONPATH": PROJECT_ROOT}
+    async with stdio_client(
+        StdioServerParameters(command=sys.executable, args=[MOCK_SERVER], env=env)
+    ) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as s:
+            await s.initialize()
+            yield s
+
+
+@pytest.mark.anyio
+async def test_list_tools(session):
+    result = await session.list_tools()
+    tool_names = {t.name for t in result.tools}
+    assert tool_names == {"search", "autocomplete", "engine_info"}
+
+
+@pytest.mark.anyio
+async def test_search(session):
+    result = await session.call_tool("search", {"query": "test"})
+    assert not result.isError
+    data = json.loads(result.content[0].text)
+    assert "results" in data
+    assert len(data["results"]) > 0
+    assert data["results"][0]["title"] == "Test Result"
+
+
+@pytest.mark.anyio
+async def test_search_full_format(session):
+    result = await session.call_tool(
+        "search", {"query": "test", "format": "full", "max_results": 1}
+    )
+    assert not result.isError
+    data = json.loads(result.content[0].text)
+    assert data["results"][0].get("engines") is not None
+
+
+@pytest.mark.anyio
+async def test_autocomplete(session):
+    result = await session.call_tool("autocomplete", {"query": "test"})
+    assert not result.isError
+    data = json.loads(result.content[0].text)
+    assert isinstance(data, list)
+    assert len(data) > 0
+
+
+@pytest.mark.anyio
+async def test_engine_info(session):
+    result = await session.call_tool("engine_info", {})
+    assert not result.isError
+    data = json.loads(result.content[0].text)
+    assert "categories" in data
+    assert "engines" in data
+    assert "category_engines" in data
+    assert "general" in data["categories"]

--- a/tests/test_stdio.py
+++ b/tests/test_stdio.py
@@ -16,7 +16,7 @@ MOCK_SERVER = str(Path(__file__).parent / "stdio_server_mock.py")
 @pytest.fixture
 async def session():
     """Start the mock MCP server in stdio mode and return a connected session."""
-    env = {**os.environ, "PYTHONPATH": PROJECT_ROOT}
+    env = {"PYTHONPATH": PROJECT_ROOT, "PATH": os.environ.get("PATH", "")}
     async with stdio_client(
         StdioServerParameters(command=sys.executable, args=[MOCK_SERVER], env=env)
     ) as (read_stream, write_stream):


### PR DESCRIPTION
## Summary

- Fix broken README navigation anchor links (emoji prefix was missing)
- Add CONTRIBUTING.md reference and enhance contributing section
- Link SearXNG to its official GitHub repo in License section
- Add stdio transport integration tests (5 tests)
- Add HTTP transport integration tests (5 tests)

Both test suites verify the full MCP protocol layer (initialize, list_tools, call_tool) through their respective transports with mocked SearXNG.

## Test plan

- [x] `pytest tests/test_stdio.py -v` — 5 passed
- [x] `pytest tests/test_http.py -v` — 5 passed
- [x] `pytest tests/ -v` — 60 passed (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)