### PR TITLE
ci: add test-gate job for docs-only PR mergeability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,3 +88,23 @@ jobs:
     needs: check-changes
     if: needs.check-changes.outputs.skip != 'true'
     uses: ./.github/workflows/reusable-test.yml
+
+  test-gate:
+    needs: [check-changes, call-test]
+    if: always() && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'dev'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate test results
+        run: |
+          if [ "$SKIP" = "true" ]; then
+            echo "Tests skipped (docs-only changes)"
+            exit 0
+          fi
+          if [ "$RESULT" != "success" ]; then
+            echo "Tests failed or were cancelled"
+            exit 1
+          fi
+          echo "All tests passed"
+        env:
+          SKIP: ${{ needs.check-changes.outputs.skip }}
+          RESULT: ${{ needs.call-test.result }}


### PR DESCRIPTION
## Summary
- Add `test-gate` job to `test.yml` as a unified merge gate
- Docs-only PRs: passes immediately (no tests needed)
- Code PRs: verifies `call-test` succeeded before passing
- Dev ruleset will be updated to require `test-gate` instead of `call-test / test` + `call-test / consistency-test`

## Why
PR #54 (Chinese README) was blocked because docs-only changes skip `call-test` entirely, so the required status checks never appear. We had to temporarily remove the ruleset to merge.

## Test plan
- [x] Push-triggered CI passes with `test-gate` job succeeding
- [ ] After merge, update dev ruleset to require `test-gate`
- [ ] Verify a future docs-only PR can merge without admin override

🤖 Generated with [Claude Code](https://claude.com/claude-code)