### PR TITLE
docs: add Docker MCP Catalog to distribution channels

### DIFF
--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -14,6 +14,7 @@ Tracking all platforms where searxng-http-mcp is published, submitted, or planne
 
 | Platform | Submitted | Status | Link |
 |----------|-----------|--------|------|
+| Docker MCP Catalog | 2026-05-11 | PR pending | [#3389](https://github.com/docker/mcp-registry/pull/3389) |
 | awesome-mcp-servers (86k stars) | 2026-05-11 | PR pending | [#6181](https://github.com/punkpeye/awesome-mcp-servers/pull/6181) |
 | Glama.ai | 2026-05-11 | Pending review | [glama.ai/mcp/servers](https://glama.ai/mcp/servers) |
 | mcpservers.org | 2026-05-11 | Pending review | [mcpservers.org](https://mcpservers.org) |


### PR DESCRIPTION
## Summary
- Add Docker MCP Catalog to Pending Review table in `docs/distribution.md`
- PR submitted: docker/mcp-registry#3389

## Test plan
- [x] CI passes (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)