### PR TITLE
feat: add glama.json for Glama.ai registry

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -25,7 +25,7 @@
   "remoteServers": [
     {
       "type": "streamable-http",
-      "url": "https://your-instance.example.com/"
+      "url": "https://your-instance.example.com/mcp/"
     }
   ],
   "mcpServers": {
@@ -33,7 +33,6 @@
       "command": "docker",
       "args": [
         "run", "-i", "--rm",
-        "-e", "SEARXNG_URL=http://host.docker.internal:8080",
         "ghcr.io/whw23/searxng-http-mcp:latest",
         "--stdio"
       ]

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["whw23"],
+  "name": "searxng-http-mcp",
+  "description": "Privacy-first metasearch MCP server powered by SearXNG. Aggregates 200+ search engines with API key auth, reverse proxy, and multi-page fanout. Supports HTTP and stdio transports.",
+  "repository": "https://github.com/whw23/searxng_http_mcp",
+  "license": "MIT",
+  "runtime": "python",
+  "categories": ["search", "web", "privacy"],
+  "keywords": ["searxng", "metasearch", "web-search", "privacy", "mcp", "search-engine"],
+  "tools": [
+    {
+      "name": "search",
+      "description": "Search the web using SearXNG metasearch engine. Aggregates results from 200+ engines with multi-page fanout, filtering by category/engine/language/time range."
+    },
+    {
+      "name": "autocomplete",
+      "description": "Get search query suggestions from SearXNG for a given partial query."
+    },
+    {
+      "name": "engine_info",
+      "description": "Get available search engines and categories from the SearXNG instance, grouped by category."
+    }
+  ],
+  "remoteServers": [
+    {
+      "type": "streamable-http",
+      "url": "https://your-instance.example.com/"
+    }
+  ],
+  "mcpServers": {
+    "searxng-http-mcp": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "SEARXNG_URL=http://host.docker.internal:8080",
+        "ghcr.io/whw23/searxng-http-mcp:latest",
+        "--stdio"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `glama.json` metadata file to enable quality scoring and installation eligibility on [Glama.ai](https://glama.ai/mcp/servers/whw23/searxng-http-mcp)
- Includes maintainer info, tool definitions, transport config, and keywords for discoverability
- Unblocks [awesome-mcp-servers PR #6181](https://github.com/punkpeye/awesome-mcp-servers/pull/6181) which requires a Glama quality score badge

## Test plan

- [x] CI passes (no code changes, metadata file only)
- [ ] After merge: verify Glama picks up the file and updates quality checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)