### PR TITLE
feat: add Glama hosting support scripts

### DIFF
--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -9,6 +9,7 @@ Tracking all platforms where searxng-http-mcp is published, submitted, or planne
 | MCP Registry | [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io/?q=io.github.whw23/searxng-http-mcp) | Official MCP registry |
 | GitHub Container Registry | [ghcr.io/whw23/searxng-http-mcp](https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp) | Docker image |
 | Claude Code Plugin Marketplace | `whw23/searxng_http_mcp` | Local + remote plugins |
+| Glama.ai | [glama.ai/mcp/servers/whw23/searxng_http_mcp](https://glama.ai/mcp/servers/whw23/searxng_http_mcp) | Listed + Release published (2026-05-14) |
 
 ## Pending Review
 
@@ -16,7 +17,6 @@ Tracking all platforms where searxng-http-mcp is published, submitted, or planne
 |----------|-----------|--------|------|
 | Docker MCP Catalog | 2026-05-11 | PR pending | [#3389](https://github.com/docker/mcp-registry/pull/3389) |
 | awesome-mcp-servers (86k stars) | 2026-05-11 | PR pending | [#6181](https://github.com/punkpeye/awesome-mcp-servers/pull/6181) |
-| Glama.ai | 2026-05-11 | ✅ Listed + Release published (2026-05-14) | [glama.ai/mcp/servers/whw23/searxng_http_mcp](https://glama.ai/mcp/servers/whw23/searxng_http_mcp) |
 | mcpservers.org | 2026-05-11 | Pending review | [mcpservers.org](https://mcpservers.org) |
 
 ## Not Yet Submitted

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -16,7 +16,7 @@ Tracking all platforms where searxng-http-mcp is published, submitted, or planne
 |----------|-----------|--------|------|
 | Docker MCP Catalog | 2026-05-11 | PR pending | [#3389](https://github.com/docker/mcp-registry/pull/3389) |
 | awesome-mcp-servers (86k stars) | 2026-05-11 | PR pending | [#6181](https://github.com/punkpeye/awesome-mcp-servers/pull/6181) |
-| Glama.ai | 2026-05-11 | Pending review | [glama.ai/mcp/servers](https://glama.ai/mcp/servers) |
+| Glama.ai | 2026-05-11 | ✅ Listed + Release published (2026-05-14) | [glama.ai/mcp/servers/whw23/searxng_http_mcp](https://glama.ai/mcp/servers/whw23/searxng_http_mcp) |
 | mcpservers.org | 2026-05-11 | Pending review | [mcpservers.org](https://mcpservers.org) |
 
 ## Not Yet Submitted

--- a/scripts/glama-settings.yml
+++ b/scripts/glama-settings.yml
@@ -1,0 +1,11 @@
+use_default_settings: true
+
+search:
+  formats:
+    - html
+    - json
+
+server:
+  secret_key: "glama-mcp-deployment"
+  port: 8080
+  bind_address: "127.0.0.1"

--- a/scripts/glama-settings.yml
+++ b/scripts/glama-settings.yml
@@ -6,6 +6,6 @@ search:
     - json
 
 server:
-  secret_key: "glama-mcp-deployment"
+  secret_key: "${SEARXNG_SECRET_KEY}"
   port: 8080
   bind_address: "127.0.0.1"

--- a/scripts/glama-start.sh
+++ b/scripts/glama-start.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 set -e
 
-# Start SearXNG Flask dev server in background
-SEARXNG_SETTINGS_PATH=/etc/searxng/settings.yml python -m searx.webapp >/dev/null 2>&1 &
+# Start SearXNG Flask dev server in background (logs to stderr for diagnostics)
+SEARXNG_SETTINGS_PATH=/etc/searxng/settings.yml python -m searx.webapp >&2 2>&1 &
 
 # Wait for SearXNG to be ready
 i=0
 while [ "$i" -lt 30 ]; do
     if wget -qO /dev/null http://127.0.0.1:8080/ 2>/dev/null; then
+        echo "SearXNG is ready." >&2
         break
     fi
     i=$((i + 1))
@@ -15,7 +16,7 @@ while [ "$i" -lt 30 ]; do
 done
 
 if [ "$i" -eq 30 ]; then
-    echo "SearXNG failed to start" >&2
+    echo "SearXNG failed to start after 30 seconds." >&2
     exit 1
 fi
 

--- a/scripts/glama-start.sh
+++ b/scripts/glama-start.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+# Start SearXNG Flask dev server in background
+SEARXNG_SETTINGS_PATH=/etc/searxng/settings.yml python -m searx.webapp >/dev/null 2>&1 &
+
+# Wait for SearXNG to be ready
+i=0
+while [ "$i" -lt 30 ]; do
+    if wget -qO /dev/null http://127.0.0.1:8080/ 2>/dev/null; then
+        break
+    fi
+    i=$((i + 1))
+    sleep 1
+done
+
+if [ "$i" -eq 30 ]; then
+    echo "SearXNG failed to start" >&2
+    exit 1
+fi
+
+# Start MCP server in stdio mode
+exec .venv/bin/python -m mcp_server.main --stdio


### PR DESCRIPTION
## Summary

- Add `scripts/glama-settings.yml`: minimal SearXNG config with JSON format enabled
- Add `scripts/glama-start.sh`: starts SearXNG in background then MCP server in stdio mode
- These scripts enable functional Glama-hosted deployments (SearXNG + MCP server in one container)

## Test plan

- [x] CI passes
- [ ] After merge: update Glama build config to use these scripts and verify search works

🤖 Generated with [Claude Code](https://claude.com/claude-code)