### PR TITLE
fix: use venv python for SearXNG in Glama start script

### DIFF
--- a/scripts/glama-start.sh
+++ b/scripts/glama-start.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Start SearXNG Flask dev server in background (logs to stderr for diagnostics)
-SEARXNG_SETTINGS_PATH=/etc/searxng/settings.yml python -m searx.webapp >&2 2>&1 &
+SEARXNG_SETTINGS_PATH=/etc/searxng/settings.yml .venv/bin/python -m searx.webapp >&2 2>&1 &
 
 # Wait for SearXNG to be ready
 i=0


### PR DESCRIPTION
## Summary

Fix Glama build failure: Debian trixie's system Python is externally managed and refuses `--system` pip installs. Use `.venv/bin/python` for SearXNG in `glama-start.sh`.

## Test plan

- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)