### PR TITLE
fix: use port 9090 for SearXNG in Glama deployment

### DIFF
--- a/scripts/glama-settings.yml
+++ b/scripts/glama-settings.yml
@@ -7,5 +7,5 @@ search:
 
 server:
   secret_key: "${SEARXNG_SECRET_KEY}"
-  port: 8080
+  port: 9090
   bind_address: "127.0.0.1"

--- a/scripts/glama-start.sh
+++ b/scripts/glama-start.sh
@@ -7,7 +7,7 @@ SEARXNG_SETTINGS_PATH=/etc/searxng/settings.yml .venv/bin/python -m searx.webapp
 # Wait for SearXNG to be ready
 i=0
 while [ "$i" -lt 30 ]; do
-    if wget -qO /dev/null http://127.0.0.1:8080/ 2>/dev/null; then
+    if wget -qO /dev/null http://127.0.0.1:9090/ 2>/dev/null; then
         echo "SearXNG is ready." >&2
         break
     fi
@@ -21,4 +21,5 @@ if [ "$i" -eq 30 ]; then
 fi
 
 # Start MCP server in stdio mode
+export SEARXNG_URL=http://127.0.0.1:9090
 exec .venv/bin/python -m mcp_server.main --stdio


### PR DESCRIPTION
## Summary

mcp-proxy listens on 8080 by default, conflicting with SearXNG. Move SearXNG to 9090 and set SEARXNG_URL accordingly in glama-start.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)