### PR TITLE
ci: switch PyPI to SemVer, bump to 1.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,12 +183,9 @@ jobs:
         uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5
 
       - name: Build package
-        run: |
-          VERSION="$(date -u +%Y).${RUN_NUMBER}.0"
-          sed -i "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
-          uv build
-        env:
-          RUN_NUMBER: ${{ github.run_number }}
+        run: uv build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        with:
+          skip-existing: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["mcp_server"]
 
 [project]
 name = "searxng-http-mcp"
-version = "1.0.0"
+version = "1.1.0"
 description = "SearXNG metasearch engine MCP server"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Remove CalVer (`YYYY.N.0`) version override from PyPI build step
- Use static SemVer from `pyproject.toml` — bump version there when releasing
- Add `skip-existing: true` so re-runs don't fail on duplicate versions
- Bump to `1.1.0` for this release (uvx support, standalone plugin, Glama hosting)

## How to release a new PyPI version

1. Bump `version` in `pyproject.toml`
2. Merge to main
3. CI auto-publishes the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)