### PR TITLE
ci: unify versioning and add auto GitHub Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,10 +152,10 @@ jobs:
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
 
-      - name: Update server.json version
+      - name: Sync server.json version from pyproject.toml
         if: steps.decide.outputs.should_build == 'true'
         run: |
-          VERSION="$(date -u +%Y).${{ github.run_number }}.0"
+          VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           jq --arg v "$VERSION" '.version = $v' server.json > server.tmp && mv server.tmp server.json
 
       - name: Authenticate to MCP Registry
@@ -189,3 +189,39 @@ jobs:
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           skip-existing: true
+
+  release:
+    needs: [build, pypi]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check if version changed
+        id: version
+        run: |
+          VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "current=$VERSION" >> "$GITHUB_OUTPUT"
+          if gh release view "v$VERSION" --repo "$REPO" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.exists == 'false'
+        run: |
+          gh release create "v$VERSION" \
+            --repo "$REPO" \
+            --title "v$VERSION" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ steps.version.outputs.current }}

--- a/server.json
+++ b/server.json
@@ -7,8 +7,24 @@
     "url": "https://github.com/whw23/searxng_http_mcp",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "searxng-http-mcp",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeHint": "uvx",
+      "environmentVariables": [
+        {
+          "name": "SEARXNG_URL",
+          "description": "SearXNG instance URL. Required for uvx mode.",
+          "isRequired": true,
+          "format": "string"
+        }
+      ]
+    },
     {
       "registryType": "oci",
       "identifier": "ghcr.io/whw23/searxng-http-mcp",


### PR DESCRIPTION
## Summary

- MCP Registry version synced from `pyproject.toml` (replaces CalVer)
- Add PyPI (uvx) package entry to `server.json`
- Add `release` job: auto-creates GitHub Release + tag when version changes
- Release runs after build + pypi succeed, only on push (not schedule)

## Release flow after this PR

1. Bump `version` in `pyproject.toml`
2. Merge to main
3. CI auto-publishes: Docker image + PyPI + MCP Registry + GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)