### PR TITLE
release: auto GitHub Release, unified versioning, badges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,10 +152,10 @@ jobs:
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
 
-      - name: Update server.json version
+      - name: Sync server.json version from pyproject.toml
         if: steps.decide.outputs.should_build == 'true'
         run: |
-          VERSION="$(date -u +%Y).${{ github.run_number }}.0"
+          VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           jq --arg v "$VERSION" '.version = $v' server.json > server.tmp && mv server.tmp server.json
 
       - name: Authenticate to MCP Registry
@@ -189,3 +189,39 @@ jobs:
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           skip-existing: true
+
+  release:
+    needs: [build, pypi]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check if version changed
+        id: version
+        run: |
+          VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "current=$VERSION" >> "$GITHUB_OUTPUT"
+          if gh release view "v$VERSION" --repo "$REPO" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.exists == 'false'
+        run: |
+          gh release create "v$VERSION" \
+            --repo "$REPO" \
+            --title "v$VERSION" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ steps.version.outputs.current }}

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@
   <img src="https://img.shields.io/badge/transport-HTTP%20%7C%20stdio-orange" alt="Transport">
   <img src="https://img.shields.io/badge/MCP-compatible-brightgreen" alt="MCP Compatible">
   <a href="https://pypi.org/project/searxng-http-mcp/"><img src="https://img.shields.io/pypi/v/searxng-http-mcp?logo=pypi&logoColor=white" alt="PyPI"></a>
-  <a href="https://glama.ai/mcp/servers/whw23/searxng_http_mcp"><img src="https://img.shields.io/badge/Glama-hosted-brightgreen" alt="Glama"></a>
   <a href="https://registry.modelcontextprotocol.io/?q=io.github.whw23/searxng-http-mcp"><img src="https://img.shields.io/badge/MCP_Registry-published-brightgreen" alt="MCP Registry"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/whw23/searxng_http_mcp"><img src="https://api.scorecard.dev/projects/github.com/whw23/searxng_http_mcp/badge" alt="OpenSSF Scorecard"></a>
 </p>
+
+<a href="https://glama.ai/mcp/servers/whw23/searxng_http_mcp"><img width="380" height="200" src="https://glama.ai/mcp/servers/whw23/searxng_http_mcp/badge" alt="searxng-http-mcp MCP server"></a>
 
 <p>
   <a href="README.zh-CN.md">中文</a> ·

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
   <img src="https://img.shields.io/badge/python-3.14+-blue?logo=python&logoColor=white" alt="Python 3.14+">
   <img src="https://img.shields.io/badge/transport-HTTP%20%7C%20stdio-orange" alt="Transport">
   <img src="https://img.shields.io/badge/MCP-compatible-brightgreen" alt="MCP Compatible">
+  <a href="https://pypi.org/project/searxng-http-mcp/"><img src="https://img.shields.io/pypi/v/searxng-http-mcp?logo=pypi&logoColor=white" alt="PyPI"></a>
+  <a href="https://glama.ai/mcp/servers/whw23/searxng_http_mcp"><img src="https://img.shields.io/badge/Glama-hosted-brightgreen" alt="Glama"></a>
   <a href="https://registry.modelcontextprotocol.io/?q=io.github.whw23/searxng-http-mcp"><img src="https://img.shields.io/badge/MCP_Registry-published-brightgreen" alt="MCP Registry"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/whw23/searxng_http_mcp"><img src="https://api.scorecard.dev/projects/github.com/whw23/searxng_http_mcp/badge" alt="OpenSSF Scorecard"></a>
 </p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,10 +14,11 @@
   <img src="https://img.shields.io/badge/transport-HTTP%20%7C%20stdio-orange" alt="Transport">
   <img src="https://img.shields.io/badge/MCP-compatible-brightgreen" alt="MCP Compatible">
   <a href="https://pypi.org/project/searxng-http-mcp/"><img src="https://img.shields.io/pypi/v/searxng-http-mcp?logo=pypi&logoColor=white" alt="PyPI"></a>
-  <a href="https://glama.ai/mcp/servers/whw23/searxng_http_mcp"><img src="https://img.shields.io/badge/Glama-hosted-brightgreen" alt="Glama"></a>
   <a href="https://registry.modelcontextprotocol.io/?q=io.github.whw23/searxng-http-mcp"><img src="https://img.shields.io/badge/MCP_Registry-published-brightgreen" alt="MCP Registry"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/whw23/searxng_http_mcp"><img src="https://api.scorecard.dev/projects/github.com/whw23/searxng_http_mcp/badge" alt="OpenSSF Scorecard"></a>
 </p>
+
+<a href="https://glama.ai/mcp/servers/whw23/searxng_http_mcp"><img width="380" height="200" src="https://glama.ai/mcp/servers/whw23/searxng_http_mcp/badge" alt="searxng-http-mcp MCP server"></a>
 
 <p>
   <a href="README.md">English</a> ·

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,8 @@
   <img src="https://img.shields.io/badge/python-3.14+-blue?logo=python&logoColor=white" alt="Python 3.14+">
   <img src="https://img.shields.io/badge/transport-HTTP%20%7C%20stdio-orange" alt="Transport">
   <img src="https://img.shields.io/badge/MCP-compatible-brightgreen" alt="MCP Compatible">
+  <a href="https://pypi.org/project/searxng-http-mcp/"><img src="https://img.shields.io/pypi/v/searxng-http-mcp?logo=pypi&logoColor=white" alt="PyPI"></a>
+  <a href="https://glama.ai/mcp/servers/whw23/searxng_http_mcp"><img src="https://img.shields.io/badge/Glama-hosted-brightgreen" alt="Glama"></a>
   <a href="https://registry.modelcontextprotocol.io/?q=io.github.whw23/searxng-http-mcp"><img src="https://img.shields.io/badge/MCP_Registry-published-brightgreen" alt="MCP Registry"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/whw23/searxng_http_mcp"><img src="https://api.scorecard.dev/projects/github.com/whw23/searxng_http_mcp/badge" alt="OpenSSF Scorecard"></a>
 </p>

--- a/server.json
+++ b/server.json
@@ -7,8 +7,24 @@
     "url": "https://github.com/whw23/searxng_http_mcp",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "searxng-http-mcp",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeHint": "uvx",
+      "environmentVariables": [
+        {
+          "name": "SEARXNG_URL",
+          "description": "SearXNG instance URL. Required for uvx mode.",
+          "isRequired": true,
+          "format": "string"
+        }
+      ]
+    },
     {
       "registryType": "oci",
       "identifier": "ghcr.io/whw23/searxng-http-mcp",


### PR DESCRIPTION
## Summary

- #84 — Auto GitHub Release + MCP Registry SemVer + PyPI package in server.json
- #85 — PyPI badge
- #86 — Glama native card badge (380x200, separate row)

## New release flow

Bump `version` in `pyproject.toml` → merge to main → CI auto-publishes:
- Docker image (GHCR)
- PyPI package
- MCP Registry
- GitHub Release + tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)