### PR TITLE
feat: v1.1.2 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "searxng-http-mcp",
       "source": "./plugins/local",
       "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "local", "docker"]
     },
@@ -17,7 +17,7 @@
       "name": "searxng-http-mcp-remote",
       "source": "./plugins/remote",
       "description": "SearXNG MCP server (remote HTTP) — connect to a deployed instance",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "remote", "http"]
     },
@@ -25,7 +25,7 @@
       "name": "searxng-http-mcp-standalone",
       "source": "./plugins/standalone",
       "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "uvx", "standalone"]
     }

--- a/plugins/local/.claude-plugin/plugin.json
+++ b/plugins/local/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.claude-plugin/plugin.json
+++ b/plugins/remote/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.claude-plugin/plugin.json
+++ b/plugins/standalone/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["mcp_server"]
 
 [project]
 name = "searxng-http-mcp"
-version = "1.1.1"
+version = "1.1.2"
 description = "SearXNG metasearch engine MCP server"
 readme = "README.md"
 license = "MIT"

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -4,13 +4,20 @@ set -e
 VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
 echo "Syncing version: $VERSION"
 
-sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/g" \
+# macOS sed requires -i '' while GNU sed requires -i alone
+if sed --version >/dev/null 2>&1; then
+  SED_INPLACE="sed -i"
+else
+  SED_INPLACE="sed -i ''"
+fi
+
+eval $SED_INPLACE "\"s/\\\"version\\\": \\\"[^\\\"]*\\\"/\\\"version\\\": \\\"$VERSION\\\"/g\"" \
   server.json \
   .claude-plugin/marketplace.json \
   plugins/local/.claude-plugin/plugin.json \
   plugins/remote/.claude-plugin/plugin.json \
   plugins/standalone/.claude-plugin/plugin.json
 
-sed -i "/^name = \"searxng-http-mcp\"/{n;s/version = \"[^\"]*\"/version = \"$VERSION\"/;}" uv.lock
+eval $SED_INPLACE "\"/^name = \\\"searxng-http-mcp\\\"/{n;s/version = \\\"[^\\\"]*\\\"/version = \\\"$VERSION\\\"/;}\"" uv.lock
 
 echo "Done. All version fields set to $VERSION"

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/whw23/searxng_http_mcp",
     "source": "github"
   },
-  "version": "1.1.1",
+  "version": "1.1.2",
   "packages": [
     {
       "registryType": "pypi",

--- a/uv.lock
+++ b/uv.lock
@@ -542,7 +542,7 @@ wheels = [
 
 [[package]]
 name = "searxng-http-mcp"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Bump version to 1.1.2 across all config files
- Fix sync-version.sh to work on both macOS and Linux

## Test plan

- [x] CI passes
- [x] `bash scripts/sync-version.sh` works on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)