### PR TITLE
v1.2.3 — pin pip hash in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ENV PATH="/usr/local/searxng/.venv/bin:${PATH}"
 # Install pip via ensurepip, upgrade to fix CVEs, then install MCP Server dependencies
 COPY requirements.docker.txt /tmp/requirements.docker.txt
 RUN python -m ensurepip --upgrade && \
-    python -m pip install --no-cache-dir --upgrade pip && \
+    python -m pip install --no-cache-dir "pip==26.1.1" --require-hashes --no-deps \
+        --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb && \
     python -m pip install --no-cache-dir --no-compile --require-hashes -r /tmp/requirements.docker.txt && \
     rm /tmp/requirements.docker.txt && \
     find /usr/local/searxng/.venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; true


### PR DESCRIPTION
## Summary
- Pin pip==26.1.1 with SHA256 hash in Dockerfile (resolves Scorecard alert #20)