### PR TITLE
ci: group dependabot updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      all-deps:
+        patterns: ["*"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -13,6 +16,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      all-deps:
+        patterns: ["*"]
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -20,3 +26,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      all-deps:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary
- Group all dependabot updates within each ecosystem into a single PR
- Reduces PR count from many separate PRs to at most 3 (one per ecosystem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)