### PR TITLE
docs+ci: autocomplete best-practice and dependabot auto-merge fix

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,13 +20,11 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Approve and auto-merge patch/minor/security updates
-        if: >-
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.update-type == 'security-update'
+      - name: Approve and auto-merge non-major updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: |
           gh pr review "$PR_URL" --approve
+          gh pr update-branch "$PR_URL" --rebase || true
           gh pr merge "$PR_URL" --auto --merge
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/mcp_server/tools.py
+++ b/mcp_server/tools.py
@@ -301,13 +301,16 @@ async def search(
 )
 async def autocomplete(
     query: Annotated[str, Field(
-        description="Partial query string to get suggestions for",
+        description="Partial query string to get suggestions for. Best results with 1-2 keywords (e.g., 'python async'). Single characters are too broad; full sentences return nothing.",
     )],
 ) -> str:
     """Get search query suggestions from SearXNG.
 
     Returns a list of autocomplete suggestions for the given partial query.
     Use this to discover relevant search terms before performing a full search.
+
+    Best results come from 1-2 meaningful keywords (e.g., "python async").
+    Single characters return overly broad suggestions; full sentences return none.
 
     Makes an external API call to the configured autocomplete backend (e.g., Bing, Google).
     Not suitable for full web search (use search tool) or engine discovery (use engine_info tool).

--- a/plugins/local/skills/web-search-via-searxng/SKILL.md
+++ b/plugins/local/skills/web-search-via-searxng/SKILL.md
@@ -47,9 +47,11 @@ Main search tool. Parameters:
 ### `autocomplete`
 
 Get search query suggestions. Use before searching to discover relevant terms.
+Best results come from 1-2 meaningful keywords (e.g., "python async").
+Single characters return overly broad suggestions; full sentences return none.
 Makes an external API call to the configured backend (e.g., Bing, Google).
 
-- `query` (required): Partial query to autocomplete
+- `query` (required): 1-2 keyword query to autocomplete (e.g., "python async", not "p" or full sentences)
 
 ### `engine_info`
 

--- a/plugins/remote/skills/web-search-via-searxng/SKILL.md
+++ b/plugins/remote/skills/web-search-via-searxng/SKILL.md
@@ -47,9 +47,11 @@ Main search tool. Parameters:
 ### `autocomplete`
 
 Get search query suggestions. Use before searching to discover relevant terms.
+Best results come from 1-2 meaningful keywords (e.g., "python async").
+Single characters return overly broad suggestions; full sentences return none.
 Makes an external API call to the configured backend (e.g., Bing, Google).
 
-- `query` (required): Partial query to autocomplete
+- `query` (required): 1-2 keyword query to autocomplete (e.g., "python async", not "p" or full sentences)
 
 ### `engine_info`
 

--- a/plugins/standalone/skills/web-search-via-searxng/SKILL.md
+++ b/plugins/standalone/skills/web-search-via-searxng/SKILL.md
@@ -47,9 +47,11 @@ Main search tool. Parameters:
 ### `autocomplete`
 
 Get search query suggestions. Use before searching to discover relevant terms.
+Best results come from 1-2 meaningful keywords (e.g., "python async").
+Single characters return overly broad suggestions; full sentences return none.
 Makes an external API call to the configured backend (e.g., Bing, Google).
 
-- `query` (required): Partial query to autocomplete
+- `query` (required): 1-2 keyword query to autocomplete (e.g., "python async", not "p" or full sentences)
 
 ### `engine_info`
 


### PR DESCRIPTION
## Summary
- Add query length best-practice to autocomplete tool description and plugin SKILL.md (1-2 keywords work best)
- Fix dependabot auto-merge: add `gh pr update-branch --rebase` before merge to resolve "behind base" blocks
- Broaden auto-merge condition to exclude only semver-major (fixes Docker digest updates being skipped)

## Test plan
- [x] CI passes (tests + consistency check)
- [ ] Verify autocomplete tool description shows updated text in MCP inspector
- [ ] Verify dependabot PRs #121 and #123 get auto-merged after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)