### PR TITLE
fix(docker): pin pip via hashed requirements file (closes #128)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,16 @@ FROM ghcr.io/searxng/searxng:latest@sha256:6ba4dc74513d1e3da2bde4a6c419a8c4a0ec3
 
 ENV PATH="/usr/local/searxng/.venv/bin:${PATH}"
 
-# Install pip via ensurepip, upgrade to fix CVEs, then install MCP Server dependencies
+# Install pip via ensurepip, upgrade to fix CVEs, then install MCP Server dependencies.
+# `--hash` is a per-requirement option only; passing it on the CLI fails silently
+# with `; true`, so pin pip via a hashed requirements file instead.
+COPY requirements.pip.txt /tmp/requirements.pip.txt
 COPY requirements.docker.txt /tmp/requirements.docker.txt
 RUN python -m ensurepip --upgrade && \
-    python -m pip install --no-cache-dir "pip==26.1.1" --require-hashes --no-deps \
-        --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb && \
+    python -m pip install --no-cache-dir --require-hashes --no-deps -r /tmp/requirements.pip.txt && \
     python -m pip install --no-cache-dir --no-compile --require-hashes -r /tmp/requirements.docker.txt && \
-    rm /tmp/requirements.docker.txt && \
-    find /usr/local/searxng/.venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; true
+    rm /tmp/requirements.pip.txt /tmp/requirements.docker.txt && \
+    find /usr/local/searxng/.venv -type d -name __pycache__ -exec rm -rf {} + || true
 
 # Copy MCP Server code
 COPY mcp_server/ /usr/local/searxng/mcp_server/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN python -m ensurepip --upgrade && \
     python -m pip install --no-cache-dir --require-hashes --no-deps -r /tmp/requirements.pip.txt && \
     python -m pip install --no-cache-dir --no-compile --require-hashes -r /tmp/requirements.docker.txt && \
     rm /tmp/requirements.pip.txt /tmp/requirements.docker.txt && \
-    find /usr/local/searxng/.venv -type d -name __pycache__ -exec rm -rf {} + || true
+    { find /usr/local/searxng/.venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true; }
 
 # Copy MCP Server code
 COPY mcp_server/ /usr/local/searxng/mcp_server/

--- a/requirements.pip.txt
+++ b/requirements.pip.txt
@@ -1,0 +1,2 @@
+pip==26.1.1 \
+    --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb


### PR DESCRIPTION
## Summary

- Fixes [#128](https://github.com/whw23/searxng_http_mcp_server/issues/128) — published `ghcr.io/whw23/searxng-http-mcp:latest` images since 2026-05-16 ship with **none** of the MCP server's Python dependencies installed, so startup fails with `ModuleNotFoundError: No module named 'mcp'`.
- Root cause: Dockerfile passed `--hash=sha256:...` as a CLI argument to `pip install`. `--hash` is a per-requirement option valid only inside requirements files — it has never been a CLI flag. pip exited with `no such option: --hash`, but the trailing `; true` on the `RUN` chain swallowed the non-zero exit, so buildkit reported the layer as `DONE` with an empty install.
- Move the pip self-pin into a new `requirements.pip.txt` and install it with `--require-hashes -r`, preserving the OpenSSF Scorecard Pinned-Dependencies guarantee from commit 0e69388. Replace `; true` with `|| true` scoped to just the `__pycache__` cleanup so future pip failures fail the build loudly.

## Test plan

- [x] `docker build .` succeeds locally on `linux/arm64`
- [x] `docker run --rm --entrypoint python <img> -c "import mcp; from mcp.server.fastmcp import FastMCP"` succeeds in the rebuilt image (verified against `searxng-http-mcp:fix-test`)
- [x] Container starts in HTTP mode and `Uvicorn running on http://0.0.0.0:8888` appears in logs
- [x] `pytest tests/ -v` — 60/60 passing
- [x] Push-triggered `test.yml` CI green ([run 26379530593](https://github.com/whw23/searxng_http_mcp_server/actions/runs/26379530593))
- [ ] After merge to `main`, verify rebuilt `latest` image once more before notifying the issue reporter

## Reference

- [pip secure-installs docs](https://pip.pypa.io/en/stable/topics/secure-installs/)
- [requirements file format](https://pip.pypa.io/en/stable/reference/requirements-file-format.html)