### PR TITLE
fix(docker): pin pip via hashed requirements file (closes #128)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,16 @@ FROM ghcr.io/searxng/searxng:latest@sha256:6ba4dc74513d1e3da2bde4a6c419a8c4a0ec3
 
 ENV PATH="/usr/local/searxng/.venv/bin:${PATH}"
 
-# Install pip via ensurepip, upgrade to fix CVEs, then install MCP Server dependencies
+# Install pip via ensurepip, upgrade to fix CVEs, then install MCP Server dependencies.
+# `--hash` is a per-requirement option only; passing it on the CLI fails silently
+# with `; true`, so pin pip via a hashed requirements file instead.
+COPY requirements.pip.txt /tmp/requirements.pip.txt
 COPY requirements.docker.txt /tmp/requirements.docker.txt
 RUN python -m ensurepip --upgrade && \
-    python -m pip install --no-cache-dir "pip==26.1.1" --require-hashes --no-deps \
-        --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb && \
+    python -m pip install --no-cache-dir --require-hashes --no-deps -r /tmp/requirements.pip.txt && \
     python -m pip install --no-cache-dir --no-compile --require-hashes -r /tmp/requirements.docker.txt && \
-    rm /tmp/requirements.docker.txt && \
-    find /usr/local/searxng/.venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; true
+    rm /tmp/requirements.pip.txt /tmp/requirements.docker.txt && \
+    find /usr/local/searxng/.venv -type d -name __pycache__ -exec rm -rf {} + || true
 
 # Copy MCP Server code
 COPY mcp_server/ /usr/local/searxng/mcp_server/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN python -m ensurepip --upgrade && \
     python -m pip install --no-cache-dir --require-hashes --no-deps -r /tmp/requirements.pip.txt && \
     python -m pip install --no-cache-dir --no-compile --require-hashes -r /tmp/requirements.docker.txt && \
     rm /tmp/requirements.pip.txt /tmp/requirements.docker.txt && \
-    find /usr/local/searxng/.venv -type d -name __pycache__ -exec rm -rf {} + || true
+    { find /usr/local/searxng/.venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true; }
 
 # Copy MCP Server code
 COPY mcp_server/ /usr/local/searxng/mcp_server/

--- a/requirements.pip.txt
+++ b/requirements.pip.txt
@@ -1,0 +1,2 @@
+pip==26.1.1 \
+    --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb


### PR DESCRIPTION
Release the fix for #128 — `ghcr.io/whw23/searxng-http-mcp:latest` has been shipping without any MCP Python deps since commit 0e69388 (2026-05-16) because `--hash` was passed as a CLI flag (it is per-requirement only) and the failure was masked by trailing `; true`.

Merging this triggers `build.yml`, which rebuilds and republishes the multi-arch image with the fix.

Includes Copilot-flagged follow-up: the original `|| true` repair still suffered from `((A && B) && C) || true` precedence; the cleanup is now wrapped in `{ … || true; }` so only the `__pycache__` `find` is suppressed.

## Test plan

- [x] Local `docker build --no-cache` shows `Successfully installed ... mcp-1.27.1 ...`
- [x] `import mcp` and `from mcp.server.fastmcp import FastMCP` succeed in the rebuilt image
- [x] Container starts in HTTP mode (`Uvicorn running on http://0.0.0.0:8888`)
- [x] `pytest tests/` — 60/60 passing
- [x] dev-branch CI green ([run 26379630699](https://github.com/whw23/searxng_http_mcp_server/actions/runs/26379630699))
- [ ] After merge, verify `build.yml` republishes `latest` and a fresh `docker pull` runs without `ModuleNotFoundError`
- [ ] Comment on #128 with confirmation