### PR TITLE
docs: refresh badges and distribution status

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 </picture>
 
 <p>
-  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/badge/ghcr.io-searxng--http--mcp-blue?logo=docker&logoColor=white" alt="Docker Image"></a>
+  <a href="https://github.com/whw23/searxng_http_mcp/blob/main/LICENSE"><img src="https://img.shields.io/github/license/whw23/searxng_http_mcp?color=yellow" alt="License"></a>
+  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/github/v/release/whw23/searxng_http_mcp?label=ghcr.io&logo=docker&logoColor=white" alt="Docker Image"></a>
   <a href="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml"><img src="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml/badge.svg" alt="Build Status"></a>
   <img src="https://img.shields.io/badge/python-3.14+-blue?logo=python&logoColor=white" alt="Python 3.14+">
   <img src="https://img.shields.io/badge/transport-HTTP%20%7C%20stdio-orange" alt="Transport">
@@ -17,6 +17,8 @@
   <a href="https://registry.modelcontextprotocol.io/?q=io.github.whw23/searxng-http-mcp"><img src="https://img.shields.io/badge/MCP_Registry-published-brightgreen" alt="MCP Registry"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/whw23/searxng_http_mcp"><img src="https://api.scorecard.dev/projects/github.com/whw23/searxng_http_mcp/badge" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/12854"><img src="https://www.bestpractices.dev/projects/12854/badge" alt="OpenSSF Best Practices"></a>
+  <a href="https://github.com/punkpeye/awesome-mcp-servers"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome MCP Servers"></a>
+  <a href="https://glama.ai/mcp/servers/whw23/searxng_http_mcp"><img src="https://glama.ai/mcp/servers/whw23/searxng_http_mcp/badges/score.svg" alt="Glama score"></a>
 </p>
 
 <a href="https://glama.ai/mcp/servers/whw23/searxng_http_mcp"><img width="380" height="200" src="https://glama.ai/mcp/servers/whw23/searxng_http_mcp/badge" alt="searxng-http-mcp MCP server"></a>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p>
   <a href="https://github.com/whw23/searxng_http_mcp/blob/main/LICENSE"><img src="https://img.shields.io/github/license/whw23/searxng_http_mcp?color=yellow" alt="License"></a>
-  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/github/v/release/whw23/searxng_http_mcp?label=ghcr.io&logo=docker&logoColor=white" alt="Docker Image"></a>
+  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/badge/ghcr.io-latest-blue?logo=docker&logoColor=white" alt="Docker Image"></a>
   <a href="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml"><img src="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml/badge.svg" alt="Build Status"></a>
   <img src="https://img.shields.io/badge/python-3.14+-blue?logo=python&logoColor=white" alt="Python 3.14+">
   <img src="https://img.shields.io/badge/transport-HTTP%20%7C%20stdio-orange" alt="Transport">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,8 +7,8 @@
 </picture>
 
 <p>
-  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/badge/ghcr.io-searxng--http--mcp-blue?logo=docker&logoColor=white" alt="Docker Image"></a>
+  <a href="https://github.com/whw23/searxng_http_mcp/blob/main/LICENSE"><img src="https://img.shields.io/github/license/whw23/searxng_http_mcp?color=yellow" alt="License"></a>
+  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/github/v/release/whw23/searxng_http_mcp?label=ghcr.io&logo=docker&logoColor=white" alt="Docker Image"></a>
   <a href="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml"><img src="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml/badge.svg" alt="Build Status"></a>
   <img src="https://img.shields.io/badge/python-3.14+-blue?logo=python&logoColor=white" alt="Python 3.14+">
   <img src="https://img.shields.io/badge/transport-HTTP%20%7C%20stdio-orange" alt="Transport">
@@ -17,6 +17,8 @@
   <a href="https://registry.modelcontextprotocol.io/?q=io.github.whw23/searxng-http-mcp"><img src="https://img.shields.io/badge/MCP_Registry-published-brightgreen" alt="MCP Registry"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/whw23/searxng_http_mcp"><img src="https://api.scorecard.dev/projects/github.com/whw23/searxng_http_mcp/badge" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/12854"><img src="https://www.bestpractices.dev/projects/12854/badge" alt="OpenSSF Best Practices"></a>
+  <a href="https://github.com/punkpeye/awesome-mcp-servers"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome MCP Servers"></a>
+  <a href="https://glama.ai/mcp/servers/whw23/searxng_http_mcp"><img src="https://glama.ai/mcp/servers/whw23/searxng_http_mcp/badges/score.svg" alt="Glama score"></a>
 </p>
 
 <a href="https://glama.ai/mcp/servers/whw23/searxng_http_mcp"><img width="380" height="200" src="https://glama.ai/mcp/servers/whw23/searxng_http_mcp/badge" alt="searxng-http-mcp MCP server"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 <p>
   <a href="https://github.com/whw23/searxng_http_mcp/blob/main/LICENSE"><img src="https://img.shields.io/github/license/whw23/searxng_http_mcp?color=yellow" alt="License"></a>
-  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/github/v/release/whw23/searxng_http_mcp?label=ghcr.io&logo=docker&logoColor=white" alt="Docker Image"></a>
+  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/badge/ghcr.io-latest-blue?logo=docker&logoColor=white" alt="Docker Image"></a>
   <a href="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml"><img src="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml/badge.svg" alt="Build Status"></a>
   <img src="https://img.shields.io/badge/python-3.14+-blue?logo=python&logoColor=white" alt="Python 3.14+">
   <img src="https://img.shields.io/badge/transport-HTTP%20%7C%20stdio-orange" alt="Transport">

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -11,13 +11,13 @@ Tracking all platforms where searxng-http-mcp is published, submitted, or planne
 | Claude Code Plugin Marketplace | `whw23/searxng_http_mcp` | Local + remote + standalone plugins |
 | Glama.ai | [glama.ai/mcp/servers/whw23/searxng_http_mcp](https://glama.ai/mcp/servers/whw23/searxng_http_mcp) | Listed + Release published (2026-05-14) |
 | PyPI | [pypi.org/project/searxng-http-mcp](https://pypi.org/project/searxng-http-mcp/) | `uvx searxng-http-mcp` |
+| awesome-mcp-servers (86k stars) | [#6181](https://github.com/punkpeye/awesome-mcp-servers/pull/6181) | Merged 2026-05-27 |
 
 ## Pending Review
 
 | Platform | Submitted | Status | Link |
 |----------|-----------|--------|------|
-| Docker MCP Catalog | 2026-05-11 | PR pending | [#3389](https://github.com/docker/mcp-registry/pull/3389) |
-| awesome-mcp-servers (86k stars) | 2026-05-11 | Bot checks passed, awaiting maintainer review | [#6181](https://github.com/punkpeye/awesome-mcp-servers/pull/6181) |
+| Docker MCP Catalog | 2026-05-11 | PR pending (REVIEW_REQUIRED) | [#3389](https://github.com/docker/mcp-registry/pull/3389) |
 | mcpservers.org | 2026-05-11 | Pending review | [mcpservers.org](https://mcpservers.org) |
 | Awesome-MCP-ZH (7k stars) | 2026-05-15 | PR pending | [#226](https://github.com/yzfly/Awesome-MCP-ZH/pull/226) |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ description = "SearXNG metasearch engine MCP server"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.14"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.14",
+]
 dependencies = [
     "mcp[cli]>=1.0.0",
     "httpx>=0.28",


### PR DESCRIPTION
## Summary

- **distribution.md**: awesome-mcp-servers (86k stars) PR #6181 was merged on 2026-05-27, moved to Published. Docker MCP Catalog PR annotated with current `REVIEW_REQUIRED` state.
- **READMEs (en + zh)**:
  - Added two new badges: official `awesome.re/mentioned-badge.svg` linking to punkpeye/awesome-mcp-servers, and official `glama.ai/.../badges/score.svg`.
  - Switched License and ghcr.io badges to dynamic shields.io endpoints that read from the GitHub repo (LICENSE file + latest release tag), so they stay correct without manual edits.
  - Python badge kept static for now — see below.
- **pyproject.toml**: added `Programming Language :: Python :: 3 / 3.14` classifiers. PyPI metadata for v1.1.3 had none, which caused `img.shields.io/pypi/pyversions/...` to render "missing". After the next release, the dynamic badge becomes usable; until then the README keeps the static `python-3.14+` badge.

## Test plan

- [x] `uv build` succeeds with the new classifiers
- [x] Push-triggered Test CI passed on the branch
- [ ] Verify rendered badge row in the PR preview on GitHub