### PR TITLE
docs: sync badge and distribution refresh to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 </picture>
 
 <p>
-  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/badge/ghcr.io-searxng--http--mcp-blue?logo=docker&logoColor=white" alt="Docker Image"></a>
+  <a href="https://github.com/whw23/searxng_http_mcp/blob/main/LICENSE"><img src="https://img.shields.io/github/license/whw23/searxng_http_mcp?color=yellow" alt="License"></a>
+  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/github/v/release/whw23/searxng_http_mcp?label=ghcr.io&logo=docker&logoColor=white" alt="Docker Image"></a>
   <a href="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml"><img src="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml/badge.svg" alt="Build Status"></a>
   <img src="https://img.shields.io/badge/python-3.14+-blue?logo=python&logoColor=white" alt="Python 3.14+">
   <img src="https://img.shields.io/badge/transport-HTTP%20%7C%20stdio-orange" alt="Transport">
@@ -17,6 +17,8 @@
   <a href="https://registry.modelcontextprotocol.io/?q=io.github.whw23/searxng-http-mcp"><img src="https://img.shields.io/badge/MCP_Registry-published-brightgreen" alt="MCP Registry"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/whw23/searxng_http_mcp"><img src="https://api.scorecard.dev/projects/github.com/whw23/searxng_http_mcp/badge" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/12854"><img src="https://www.bestpractices.dev/projects/12854/badge" alt="OpenSSF Best Practices"></a>
+  <a href="https://github.com/punkpeye/awesome-mcp-servers"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome MCP Servers"></a>
+  <a href="https://glama.ai/mcp/servers/whw23/searxng_http_mcp"><img src="https://glama.ai/mcp/servers/whw23/searxng_http_mcp/badges/score.svg" alt="Glama score"></a>
 </p>
 
 <a href="https://glama.ai/mcp/servers/whw23/searxng_http_mcp"><img width="380" height="200" src="https://glama.ai/mcp/servers/whw23/searxng_http_mcp/badge" alt="searxng-http-mcp MCP server"></a>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p>
   <a href="https://github.com/whw23/searxng_http_mcp/blob/main/LICENSE"><img src="https://img.shields.io/github/license/whw23/searxng_http_mcp?color=yellow" alt="License"></a>
-  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/github/v/release/whw23/searxng_http_mcp?label=ghcr.io&logo=docker&logoColor=white" alt="Docker Image"></a>
+  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/badge/ghcr.io-latest-blue?logo=docker&logoColor=white" alt="Docker Image"></a>
   <a href="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml"><img src="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml/badge.svg" alt="Build Status"></a>
   <img src="https://img.shields.io/badge/python-3.14+-blue?logo=python&logoColor=white" alt="Python 3.14+">
   <img src="https://img.shields.io/badge/transport-HTTP%20%7C%20stdio-orange" alt="Transport">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,8 +7,8 @@
 </picture>
 
 <p>
-  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/badge/ghcr.io-searxng--http--mcp-blue?logo=docker&logoColor=white" alt="Docker Image"></a>
+  <a href="https://github.com/whw23/searxng_http_mcp/blob/main/LICENSE"><img src="https://img.shields.io/github/license/whw23/searxng_http_mcp?color=yellow" alt="License"></a>
+  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/github/v/release/whw23/searxng_http_mcp?label=ghcr.io&logo=docker&logoColor=white" alt="Docker Image"></a>
   <a href="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml"><img src="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml/badge.svg" alt="Build Status"></a>
   <img src="https://img.shields.io/badge/python-3.14+-blue?logo=python&logoColor=white" alt="Python 3.14+">
   <img src="https://img.shields.io/badge/transport-HTTP%20%7C%20stdio-orange" alt="Transport">
@@ -17,6 +17,8 @@
   <a href="https://registry.modelcontextprotocol.io/?q=io.github.whw23/searxng-http-mcp"><img src="https://img.shields.io/badge/MCP_Registry-published-brightgreen" alt="MCP Registry"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/whw23/searxng_http_mcp"><img src="https://api.scorecard.dev/projects/github.com/whw23/searxng_http_mcp/badge" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/12854"><img src="https://www.bestpractices.dev/projects/12854/badge" alt="OpenSSF Best Practices"></a>
+  <a href="https://github.com/punkpeye/awesome-mcp-servers"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome MCP Servers"></a>
+  <a href="https://glama.ai/mcp/servers/whw23/searxng_http_mcp"><img src="https://glama.ai/mcp/servers/whw23/searxng_http_mcp/badges/score.svg" alt="Glama score"></a>
 </p>
 
 <a href="https://glama.ai/mcp/servers/whw23/searxng_http_mcp"><img width="380" height="200" src="https://glama.ai/mcp/servers/whw23/searxng_http_mcp/badge" alt="searxng-http-mcp MCP server"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 <p>
   <a href="https://github.com/whw23/searxng_http_mcp/blob/main/LICENSE"><img src="https://img.shields.io/github/license/whw23/searxng_http_mcp?color=yellow" alt="License"></a>
-  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/github/v/release/whw23/searxng_http_mcp?label=ghcr.io&logo=docker&logoColor=white" alt="Docker Image"></a>
+  <a href="https://github.com/whw23/searxng_http_mcp/pkgs/container/searxng-http-mcp"><img src="https://img.shields.io/badge/ghcr.io-latest-blue?logo=docker&logoColor=white" alt="Docker Image"></a>
   <a href="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml"><img src="https://github.com/whw23/searxng_http_mcp/actions/workflows/build.yml/badge.svg" alt="Build Status"></a>
   <img src="https://img.shields.io/badge/python-3.14+-blue?logo=python&logoColor=white" alt="Python 3.14+">
   <img src="https://img.shields.io/badge/transport-HTTP%20%7C%20stdio-orange" alt="Transport">

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -11,13 +11,13 @@ Tracking all platforms where searxng-http-mcp is published, submitted, or planne
 | Claude Code Plugin Marketplace | `whw23/searxng_http_mcp` | Local + remote + standalone plugins |
 | Glama.ai | [glama.ai/mcp/servers/whw23/searxng_http_mcp](https://glama.ai/mcp/servers/whw23/searxng_http_mcp) | Listed + Release published (2026-05-14) |
 | PyPI | [pypi.org/project/searxng-http-mcp](https://pypi.org/project/searxng-http-mcp/) | `uvx searxng-http-mcp` |
+| awesome-mcp-servers (86k stars) | [#6181](https://github.com/punkpeye/awesome-mcp-servers/pull/6181) | Merged 2026-05-27 |
 
 ## Pending Review
 
 | Platform | Submitted | Status | Link |
 |----------|-----------|--------|------|
-| Docker MCP Catalog | 2026-05-11 | PR pending | [#3389](https://github.com/docker/mcp-registry/pull/3389) |
-| awesome-mcp-servers (86k stars) | 2026-05-11 | Bot checks passed, awaiting maintainer review | [#6181](https://github.com/punkpeye/awesome-mcp-servers/pull/6181) |
+| Docker MCP Catalog | 2026-05-11 | PR pending (REVIEW_REQUIRED) | [#3389](https://github.com/docker/mcp-registry/pull/3389) |
 | mcpservers.org | 2026-05-11 | Pending review | [mcpservers.org](https://mcpservers.org) |
 | Awesome-MCP-ZH (7k stars) | 2026-05-15 | PR pending | [#226](https://github.com/yzfly/Awesome-MCP-ZH/pull/226) |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ description = "SearXNG metasearch engine MCP server"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.14"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.14",
+]
 dependencies = [
     "mcp[cli]>=1.0.0",
     "httpx>=0.28",


### PR DESCRIPTION
## Summary

Propagates PR #136 from dev to main:

- **distribution.md**: awesome-mcp-servers PR #6181 merged (2026-05-27) — moved to Published. Docker MCP Catalog annotated `REVIEW_REQUIRED`.
- **READMEs (en + zh)**: added official Awesome MCP + Glama score badges; switched License badge to dynamic `img.shields.io/github/license/...`; kept Docker badge static `ghcr.io/latest` (per Copilot review — dynamic release-tag badge would have been misleading since GHCR tags are `${UPSTREAM_VERSION}-${SHORT_SHA}`, not GitHub release tags).
- **pyproject.toml**: added `Programming Language :: Python :: 3 / 3.14` classifiers. Takes effect on PyPI at the next release; meanwhile README keeps the static Python badge.

Docs/chore only — no source-code behavior changes. No version bump.

## Test plan

- [x] Test CI green on dev branch (PR #136 push checks passed)
- [x] CodeQL green on dev
- [x] Copilot review addressed (Docker badge thread resolved with fix)
- [ ] Policy checks (source-branch verification, protected files) pass on this PR