### PR TITLE
release: v1.1.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "searxng-http-mcp",
       "source": "./plugins/local",
       "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "local", "docker"]
     },
@@ -17,7 +17,7 @@
       "name": "searxng-http-mcp-remote",
       "source": "./plugins/remote",
       "description": "SearXNG MCP server (remote HTTP) — connect to a deployed instance",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "remote", "http"]
     },
@@ -25,7 +25,7 @@
       "name": "searxng-http-mcp-standalone",
       "source": "./plugins/standalone",
       "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "uvx", "standalone"]
     }

--- a/plugins/local/.claude-plugin/plugin.json
+++ b/plugins/local/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/local/.codex-plugin/plugin.json
+++ b/plugins/local/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/local/.plugin/plugin.json
+++ b/plugins/local/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.claude-plugin/plugin.json
+++ b/plugins/remote/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.codex-plugin/plugin.json
+++ b/plugins/remote/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.plugin/plugin.json
+++ b/plugins/remote/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.claude-plugin/plugin.json
+++ b/plugins/standalone/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.codex-plugin/plugin.json
+++ b/plugins/standalone/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.plugin/plugin.json
+++ b/plugins/standalone/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["mcp_server"]
 
 [project]
 name = "searxng-http-mcp"
-version = "1.1.3"
+version = "1.1.4"
 description = "SearXNG metasearch engine MCP server"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/whw23/searxng_http_mcp",
     "source": "github"
   },
-  "version": "1.1.3",
+  "version": "1.1.4",
   "packages": [
     {
       "registryType": "pypi",

--- a/uv.lock
+++ b/uv.lock
@@ -621,7 +621,7 @@ wheels = [
 
 [[package]]
 name = "searxng-http-mcp"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Cuts release **v1.1.4**. Once merged, `build.yml` auto-publishes to:
- GHCR (Docker image, cosign-signed, Trivy-scanned)
- MCP Registry
- PyPI (trusted publisher, OIDC)
- GitHub Releases (`v1.1.4` tag)

## Changes since v1.1.3

- `fix(docker)`: pin pip via hashed requirements file (#128, PR #133)
- `fix(docker)`: scope cleanup error suppression to find subgroup (PR #134)
- `docs`: refresh badges and distribution status (PR #136)
- `chore(pyproject)`: add Python `3` / `3.14` Trove classifiers (PR #136)
- `chore(release)`: version bump 1.1.3 → 1.1.4 across 13 manifests (PR #138)

## Test plan

- [x] All upstream PRs (#133, #134, #136, #138) merged to dev with green CI + Copilot review
- [ ] Policy checks pass on this PR
- [ ] `build.yml` auto-release triggers on merge
- [ ] PyPI shows v1.1.4 with Python classifiers populated
- [ ] Follow-up: switch README Python badge back to dynamic `shields.io/pypi/pyversions`