### PR TITLE
feat(tools): add title annotation to MCP tools

### DIFF
--- a/mcp_server/tools.py
+++ b/mcp_server/tools.py
@@ -143,6 +143,7 @@ def _build_diagnostics(query: str, params: dict, errors: list[str]) -> dict:
 
 @mcp.tool(
     annotations=ToolAnnotations(
+        title="Web Search",
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
@@ -293,6 +294,7 @@ async def search(
 
 @mcp.tool(
     annotations=ToolAnnotations(
+        title="Autocomplete Suggestions",
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
@@ -333,6 +335,7 @@ ENGINE_INFO_CACHE_TTL = 300
 
 @mcp.tool(
     annotations=ToolAnnotations(
+        title="Engine & Category Info",
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,


### PR DESCRIPTION
## Summary
- Add human-readable `title` field to `ToolAnnotations` for all three MCP tools (`search`, `autocomplete`, `engine_info`)
- This is a new field in the MCP spec that provides a display name for clients

## Test plan
- [x] All 60 tests pass locally
- [x] Push-triggered CI passes