### PR TITLE
chore: merge dev into main

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,20 +27,14 @@ jobs:
 
       - name: Sync requirements.docker.txt with uv.lock
         run: |
-          if gh pr diff "$PR_NUMBER" --name-only --repo "$REPO" | grep -q 'uv.lock'; then
-            uv export --no-dev --no-editable --no-emit-project --format requirements-txt -o requirements.docker.txt
-            if ! git diff --quiet requirements.docker.txt; then
-              git config user.name "github-actions[bot]"
-              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-              git add requirements.docker.txt
-              git commit -m "chore: sync requirements.docker.txt with uv.lock"
-              git push
-            fi
+          uv export --no-dev --no-editable --no-emit-project --format requirements-txt -o requirements.docker.txt
+          if ! git diff --quiet requirements.docker.txt; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add requirements.docker.txt
+            git commit -m "chore: sync requirements.docker.txt with uv.lock"
+            git push
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
 
       - name: Approve and auto-merge Dependabot updates
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/searxng/searxng:latest@sha256:735156112935ab87447d981fba81367fe3fd8861a740dd93e7f26ddfe4f2848a
+FROM ghcr.io/searxng/searxng:latest@sha256:3f4f8d71632ae9fdcc49d0c1783d9faa6f384230a97841091a79bfdca7b6e370
 
 ENV PATH="/usr/local/searxng/.venv/bin:${PATH}"
 


### PR DESCRIPTION
## Summary
- #173 — fix(ci): always sync requirements.docker.txt in Dependabot auto-merge

Fixes Dependabot auto-merge for PRs that only update requirements.docker.txt without uv.lock.