### PR TITLE
fix(ci): keep Dependabot auto-merge checks fresh

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,6 +11,7 @@ jobs:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
     steps:
@@ -26,7 +27,9 @@ jobs:
           python-version: "3.14"
 
       - name: Sync requirements.docker.txt with uv.lock
+        id: sync-requirements
         run: |
+          echo "changed=false" >> "$GITHUB_OUTPUT"
           uv export --no-dev --no-editable --no-emit-project --format requirements-txt -o requirements.docker.txt
           if ! git diff --quiet requirements.docker.txt; then
             git config user.name "github-actions[bot]"
@@ -34,7 +37,15 @@ jobs:
             git add requirements.docker.txt
             git commit -m "chore: sync requirements.docker.txt with uv.lock"
             git push
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Run tests for synced requirements
+        if: steps.sync-requirements.outputs.changed == 'true'
+        run: gh workflow run test.yml --ref "$HEAD_REF"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
 
       - name: Approve and auto-merge Dependabot updates
         run: |

--- a/.github/workflows/dependabot-update-branches.yml
+++ b/.github/workflows/dependabot-update-branches.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           gh pr list --state open --base dev --limit 100 \
             --json number,headRefName,author,mergeStateStatus \
-            --jq '.[] | select(.author.login == "app/dependabot" and .mergeStateStatus == "BEHIND") | [.number, .headRefName] | @tsv' > stale-prs.tsv
+            --jq '.[] | select(.author.login == "dependabot[bot]" and .mergeStateStatus == "BEHIND") | [.number, .headRefName] | @tsv' > stale-prs.tsv
 
           if [ ! -s stale-prs.tsv ]; then
             echo "No stale Dependabot branches found."

--- a/.github/workflows/dependabot-update-branches.yml
+++ b/.github/workflows/dependabot-update-branches.yml
@@ -1,0 +1,35 @@
+name: Dependabot Update Branches
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  update-branches:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Update stale Dependabot branches
+        run: |
+          gh pr list --state open --base dev --limit 100 \
+            --json number,headRefName,author,mergeStateStatus \
+            --jq '.[] | select(.author.login == "app/dependabot" and .mergeStateStatus == "BEHIND") | [.number, .headRefName] | @tsv' > stale-prs.tsv
+
+          if [ ! -s stale-prs.tsv ]; then
+            echo "No stale Dependabot branches found."
+            exit 0
+          fi
+
+          while IFS=$'\t' read -r number head_ref; do
+            echo "Updating PR #$number ($head_ref)"
+            gh pr update-branch "$number"
+            gh workflow run test.yml --ref "$head_ref"
+          done < stale-prs.tsv
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-update-branches.yml
+++ b/.github/workflows/dependabot-update-branches.yml
@@ -32,4 +32,5 @@ jobs:
             gh workflow run test.yml --ref "$head_ref"
           done < stale-prs.tsv
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore: [main]
   pull_request:
     branches: [dev, main]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -47,7 +48,7 @@ jobs:
           REPO: ${{ github.repository }}
 
   check-changes:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'dev')
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.base_ref == 'dev')
     runs-on: ubuntu-latest
     outputs:
       skip: ${{ steps.changes.outputs.skip }}
@@ -60,7 +61,11 @@ jobs:
       - name: Check for docs-only changes
         id: changes
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Manual run, running tests."
+            exit 0
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
             FILES=$(gh pr diff "$PR_NUMBER" --name-only --repo "$REPO")
           else
             if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
@@ -91,7 +96,7 @@ jobs:
 
   test-gate:
     needs: [check-changes, call-test]
-    if: always() && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'dev'))
+    if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.base_ref == 'dev'))
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate test results


### PR DESCRIPTION
## Summary
- dispatch the Test workflow for Dependabot sync commits so required checks appear on the latest PR head
- add a workflow to update stale Dependabot PR branches after dev changes
- allow Test to run via workflow_dispatch without docs-only skipping

## Testing
- git diff --check
- parsed changed workflow YAML files with Ruby