### PR TITLE
fix(ci): support Dependabot app author in branch updater

### DIFF
--- a/.github/workflows/dependabot-update-branches.yml
+++ b/.github/workflows/dependabot-update-branches.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           gh pr list --state open --base dev --limit 100 \
             --json number,headRefName,author,mergeStateStatus \
-            --jq '.[] | select(.author.login == "dependabot[bot]" and .mergeStateStatus == "BEHIND") | [.number, .headRefName] | @tsv' > stale-prs.tsv
+            --jq '.[] | select((.author.login == "dependabot[bot]" or .author.login == "app/dependabot") and .mergeStateStatus == "BEHIND") | [.number, .headRefName] | @tsv' > stale-prs.tsv
 
           if [ ! -s stale-prs.tsv ]; then
             echo "No stale Dependabot branches found."


### PR DESCRIPTION
## Summary
- accept both Dependabot author login formats in the stale branch updater
- keeps the updater compatible with gh pr list author output

## Testing
- git diff --check
- parsed workflow YAML with Ruby