### PR TITLE
fix: redirect /mcp to /mcp/

### DIFF
--- a/mcp_server/app.py
+++ b/mcp_server/app.py
@@ -2,11 +2,18 @@ import contextlib
 import os
 
 from starlette.applications import Starlette
-from starlette.routing import Mount
+from starlette.requests import Request
+from starlette.responses import RedirectResponse
+from starlette.routing import Mount, Route
 
 from mcp_server.auth import AuthMiddleware
 from mcp_server.proxy import ReverseProxyApp
 from mcp_server.tools import mcp, fetch_engine_info, cleanup as tools_cleanup
+
+
+def _redirect_to_mcp_slash(request: Request) -> RedirectResponse:
+    """Redirect /mcp to /mcp/ because Starlette Mount requires a trailing slash."""
+    return RedirectResponse(url="/mcp/")
 
 
 def create_app() -> Starlette:
@@ -39,6 +46,7 @@ def create_app() -> Starlette:
     starlette_app = Starlette(
         routes=[
             Mount("/mcp", app=mcp.streamable_http_app()),
+            Route("/mcp", endpoint=_redirect_to_mcp_slash),
             Mount("/", app=proxy),
         ],
         lifespan=lifespan,

--- a/mcp_server/app.py
+++ b/mcp_server/app.py
@@ -13,7 +13,10 @@ from mcp_server.tools import mcp, fetch_engine_info, cleanup as tools_cleanup
 
 def _redirect_to_mcp_slash(request: Request) -> RedirectResponse:
     """Redirect /mcp to /mcp/ because Starlette Mount requires a trailing slash."""
-    return RedirectResponse(url="/mcp/")
+    target = "/mcp/"
+    if request.url.query:
+        target += "?" + request.url.query
+    return RedirectResponse(url=target)
 
 
 def create_app() -> Starlette:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,6 +29,27 @@ class TestAppNoAuth:
         assert resp.status_code != 404
 
     @patch.dict("os.environ", {}, clear=True)
+    def test_mcp_without_slash_redirects(self):
+        from mcp_server.app import create_app
+
+        app = create_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/mcp", follow_redirects=False)
+        assert resp.status_code == 307
+        assert resp.headers["location"] == "/mcp/"
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_mcp_with_slash_hits_mcp_app(self):
+        from mcp_server.app import create_app
+
+        app = create_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/mcp/")
+        # The MCP app is reached (it does not fall through to the proxy).
+        assert resp.status_code != 404
+        assert "location" not in resp.headers
+
+    @patch.dict("os.environ", {}, clear=True)
     @patch("mcp_server.proxy.httpx.AsyncClient")
     def test_proxy_route_forwards(self, mock_client_cls):
         mock_client_cls.return_value = _make_proxy_mock()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -39,7 +39,8 @@ class TestAppNoAuth:
         assert resp.headers["location"] == "/mcp/"
 
     @patch.dict("os.environ", {}, clear=True)
-    def test_mcp_with_slash_hits_mcp_app(self):
+    @patch("mcp_server.proxy.httpx.AsyncClient")
+    def test_mcp_with_slash_hits_mcp_app(self, mock_client_cls):
         from mcp_server.app import create_app
 
         app = create_app()
@@ -48,6 +49,17 @@ class TestAppNoAuth:
         # The MCP app is reached (it does not fall through to the proxy).
         assert resp.status_code != 404
         assert "location" not in resp.headers
+        mock_client_cls.assert_not_called()
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_mcp_redirect_preserves_query_string(self):
+        from mcp_server.app import create_app
+
+        app = create_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/mcp?foo=1", follow_redirects=False)
+        assert resp.status_code == 307
+        assert resp.headers["location"] == "/mcp/?foo=1"
 
     @patch.dict("os.environ", {}, clear=True)
     @patch("mcp_server.proxy.httpx.AsyncClient")


### PR DESCRIPTION
## Problem

The MCP HTTP endpoint was only accessible at `/mcp/`; a request to `/mcp` fell through to the SearXNG reverse proxy because Starlette's `Mount("/mcp")` only matches paths with a trailing slash.

## Change

Add an explicit `/mcp` route that returns a `307` redirect to `/mcp/`.

## Verification

- Added tests for the redirect and for `/mcp/` still hitting the MCP app.
- Full test suite passes locally and in CI.