### PR TITLE
chore(release): bump version to 1.1.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "searxng-http-mcp",
       "source": "./plugins/local",
       "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "local", "docker"]
     },
@@ -17,7 +17,7 @@
       "name": "searxng-http-mcp-remote",
       "source": "./plugins/remote",
       "description": "SearXNG MCP server (remote HTTP) — connect to a deployed instance",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "remote", "http"]
     },
@@ -25,7 +25,7 @@
       "name": "searxng-http-mcp-standalone",
       "source": "./plugins/standalone",
       "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "uvx", "standalone"]
     }

--- a/plugins/local/.claude-plugin/plugin.json
+++ b/plugins/local/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/local/.codex-plugin/plugin.json
+++ b/plugins/local/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/local/.plugin/plugin.json
+++ b/plugins/local/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.claude-plugin/plugin.json
+++ b/plugins/remote/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.codex-plugin/plugin.json
+++ b/plugins/remote/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.plugin/plugin.json
+++ b/plugins/remote/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.claude-plugin/plugin.json
+++ b/plugins/standalone/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.codex-plugin/plugin.json
+++ b/plugins/standalone/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.plugin/plugin.json
+++ b/plugins/standalone/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["mcp_server"]
 
 [project]
 name = "searxng-http-mcp"
-version = "1.1.4"
+version = "1.1.5"
 description = "SearXNG metasearch engine MCP server"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/whw23/searxng_http_mcp",
     "source": "github"
   },
-  "version": "1.1.4",
+  "version": "1.1.5",
   "packages": [
     {
       "registryType": "pypi",

--- a/uv.lock
+++ b/uv.lock
@@ -650,7 +650,7 @@ wheels = [
 
 [[package]]
 name = "searxng-http-mcp"
-version = "1.1.4"
+version = "1.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Bump version from `1.1.4` to `1.1.5` across all configuration files.

## Changes

- `pyproject.toml`: `version = "1.1.5"`
- `uv.lock`: synced package version
- `server.json`: synced version field
- `.claude-plugin/marketplace.json`: synced version fields
- All plugin manifests under `plugins/{local,remote,standalone}/`: synced version fields

## Verification

- `bash scripts/sync-version.sh` executed successfully.
- Full test suite passes (63 tests, coverage 94%+).
