### PR TITLE
fix: handle /mcp natively without redirect

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "searxng-http-mcp",
       "source": "./plugins/local",
       "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "local", "docker"]
     },
@@ -17,7 +17,7 @@
       "name": "searxng-http-mcp-remote",
       "source": "./plugins/remote",
       "description": "SearXNG MCP server (remote HTTP) — connect to a deployed instance",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "remote", "http"]
     },
@@ -25,7 +25,7 @@
       "name": "searxng-http-mcp-standalone",
       "source": "./plugins/standalone",
       "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "uvx", "standalone"]
     }

--- a/mcp_server/app.py
+++ b/mcp_server/app.py
@@ -1,35 +1,40 @@
 import contextlib
 import os
 
+from mcp.server.fastmcp import FastMCP
 from starlette.applications import Starlette
 from starlette.routing import Mount, Route
 from starlette.types import Receive, Scope, Send
 
 from mcp_server.auth import AuthMiddleware
 from mcp_server.proxy import ReverseProxyApp
-from mcp_server.tools import mcp, fetch_engine_info, cleanup as tools_cleanup
+from mcp_server.tools import mcp as tools_mcp, fetch_engine_info, cleanup as tools_cleanup
 
 
-def _make_mcp_app(inner_app):
-    """Return an ASGI app that serves the MCP app at /mcp and /mcp/.
+class _MCPApp:
+    """ASGI app wrapper that serves the MCP app at /mcp and /mcp/.
 
-    When mounted at /mcp, Starlette strips the prefix and passes an empty
-    path for /mcp. When routed via Route("/mcp"), the path is /mcp. The
-    inner MCP app route is /, so normalize both to /.
+    When mounted at /mcp, Starlette sets the remaining path to /mcp/ and
+    records the matched prefix in root_path. When routed via Route("/mcp"),
+    the path is /mcp. The inner MCP app route is /, so normalize the bare
+    /mcp case to / before dispatching.
     """
 
-    async def _mcp_app(scope: Scope, receive: Receive, send: Send) -> None:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] in ("http", "websocket") and scope.get("path") in ("", "/mcp"):
             scope = dict(scope)
             scope["path"] = "/"
             scope["raw_path"] = b"/"
-        await inner_app(scope, receive, send)
-
-    return _mcp_app
+        await self.app(scope, receive, send)
 
 
-def create_app() -> Starlette:
+def create_app(mcp_instance: FastMCP | None = None) -> Starlette:
     """Create the Starlette ASGI app with MCP, auth, and reverse proxy."""
+    mcp = mcp_instance or tools_mcp
+
     api_key = os.environ.get("API_KEY", "")
     searxng_url = os.environ.get("SEARXNG_URL", "http://127.0.0.1:8080")
 
@@ -55,7 +60,7 @@ def create_app() -> Starlette:
                 await tools_cleanup()
                 await proxy.aclose()
 
-    mcp_app = _make_mcp_app(mcp.streamable_http_app())
+    mcp_app = _MCPApp(mcp.streamable_http_app())
 
     starlette_app = Starlette(
         routes=[

--- a/mcp_server/app.py
+++ b/mcp_server/app.py
@@ -2,21 +2,26 @@ import contextlib
 import os
 
 from starlette.applications import Starlette
-from starlette.requests import Request
-from starlette.responses import RedirectResponse
 from starlette.routing import Mount, Route
+from starlette.types import Receive, Scope, Send
 
 from mcp_server.auth import AuthMiddleware
 from mcp_server.proxy import ReverseProxyApp
 from mcp_server.tools import mcp, fetch_engine_info, cleanup as tools_cleanup
 
 
-def _redirect_to_mcp_slash(request: Request) -> RedirectResponse:
-    """Redirect /mcp to /mcp/ because Starlette Mount requires a trailing slash."""
-    target = "/mcp/"
-    if request.url.query:
-        target += "?" + request.url.query
-    return RedirectResponse(url=target)
+async def _mcp_app(scope: Scope, receive: Receive, send: Send) -> None:
+    """Serve the MCP app at /mcp and /mcp/.
+
+    When mounted at /mcp, Starlette strips the prefix and passes an empty
+    path for /mcp. When routed via Route("/mcp"), the path is /mcp. The
+    inner MCP app route is /, so normalize both to /.
+    """
+    if scope["type"] in ("http", "websocket") and scope.get("path") in ("", "/mcp"):
+        scope = dict(scope)
+        scope["path"] = "/"
+        scope["raw_path"] = b"/"
+    await mcp.streamable_http_app()(scope, receive, send)
 
 
 def create_app() -> Starlette:
@@ -48,8 +53,8 @@ def create_app() -> Starlette:
 
     starlette_app = Starlette(
         routes=[
-            Mount("/mcp", app=mcp.streamable_http_app()),
-            Route("/mcp", endpoint=_redirect_to_mcp_slash),
+            Mount("/mcp", app=_mcp_app),
+            Route("/mcp", endpoint=_mcp_app, methods=["GET", "POST", "HEAD"]),
             Mount("/", app=proxy),
         ],
         lifespan=lifespan,

--- a/mcp_server/app.py
+++ b/mcp_server/app.py
@@ -10,18 +10,22 @@ from mcp_server.proxy import ReverseProxyApp
 from mcp_server.tools import mcp, fetch_engine_info, cleanup as tools_cleanup
 
 
-async def _mcp_app(scope: Scope, receive: Receive, send: Send) -> None:
-    """Serve the MCP app at /mcp and /mcp/.
+def _make_mcp_app(inner_app):
+    """Return an ASGI app that serves the MCP app at /mcp and /mcp/.
 
     When mounted at /mcp, Starlette strips the prefix and passes an empty
     path for /mcp. When routed via Route("/mcp"), the path is /mcp. The
     inner MCP app route is /, so normalize both to /.
     """
-    if scope["type"] in ("http", "websocket") and scope.get("path") in ("", "/mcp"):
-        scope = dict(scope)
-        scope["path"] = "/"
-        scope["raw_path"] = b"/"
-    await mcp.streamable_http_app()(scope, receive, send)
+
+    async def _mcp_app(scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] in ("http", "websocket") and scope.get("path") in ("", "/mcp"):
+            scope = dict(scope)
+            scope["path"] = "/"
+            scope["raw_path"] = b"/"
+        await inner_app(scope, receive, send)
+
+    return _mcp_app
 
 
 def create_app() -> Starlette:
@@ -51,10 +55,12 @@ def create_app() -> Starlette:
                 await tools_cleanup()
                 await proxy.aclose()
 
+    mcp_app = _make_mcp_app(mcp.streamable_http_app())
+
     starlette_app = Starlette(
         routes=[
-            Mount("/mcp", app=_mcp_app),
-            Route("/mcp", endpoint=_mcp_app, methods=["GET", "POST", "HEAD"]),
+            Mount("/mcp", app=mcp_app),
+            Route("/mcp", endpoint=mcp_app, methods=["GET", "POST", "HEAD"]),
             Mount("/", app=proxy),
         ],
         lifespan=lifespan,

--- a/plugins/local/.claude-plugin/plugin.json
+++ b/plugins/local/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/local/.codex-plugin/plugin.json
+++ b/plugins/local/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/local/.plugin/plugin.json
+++ b/plugins/local/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.claude-plugin/plugin.json
+++ b/plugins/remote/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.codex-plugin/plugin.json
+++ b/plugins/remote/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.plugin/plugin.json
+++ b/plugins/remote/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.claude-plugin/plugin.json
+++ b/plugins/standalone/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.codex-plugin/plugin.json
+++ b/plugins/standalone/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.plugin/plugin.json
+++ b/plugins/standalone/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["mcp_server"]
 
 [project]
 name = "searxng-http-mcp"
-version = "1.1.5"
+version = "1.1.6"
 description = "SearXNG metasearch engine MCP server"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/whw23/searxng_http_mcp",
     "source": "github"
   },
-  "version": "1.1.5",
+  "version": "1.1.6",
   "packages": [
     {
       "registryType": "pypi",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,9 @@
 import base64
+import os
 from unittest.mock import patch, AsyncMock, MagicMock
 
+import pytest
+from mcp.server.fastmcp import FastMCP
 from starlette.testclient import TestClient
 
 
@@ -18,68 +21,64 @@ def _make_proxy_mock():
     return mock_client
 
 
+@pytest.fixture(scope="module")
+def no_auth_client():
+    """Shared TestClient with lifespan active and no API key."""
+    os.environ.pop("API_KEY", None)
+    test_mcp = FastMCP(
+        "test",
+        stateless_http=True,
+        json_response=True,
+        streamable_http_path="/",
+    )
+
+    @test_mcp.tool()
+    async def ping() -> str:
+        return "pong"
+
+    from mcp_server.app import create_app
+
+    app = create_app(mcp_instance=test_mcp)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+
+
 class TestAppNoAuth:
-    @patch.dict("os.environ", {}, clear=True)
-    def test_mcp_endpoint_accessible(self):
-        from mcp_server.app import create_app
+    def test_mcp_endpoint_accessible(self, no_auth_client):
+        resp = no_auth_client.get("/mcp")
+        assert resp.status_code < 500
 
-        app = create_app()
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.get("/mcp")
-        assert resp.status_code != 404
+    def test_mcp_without_slash_hits_mcp_app(self, no_auth_client):
+        with patch("mcp_server.proxy.httpx.AsyncClient") as mock_client_cls:
+            resp = no_auth_client.get("/mcp")
+            # The MCP app is reached directly; no redirect and no proxy fallback.
+            assert resp.status_code < 500
+            assert "location" not in resp.headers
+            mock_client_cls.assert_not_called()
 
-    @patch.dict("os.environ", {}, clear=True)
-    @patch("mcp_server.proxy.httpx.AsyncClient")
-    def test_mcp_without_slash_hits_mcp_app(self, mock_client_cls):
-        from mcp_server.app import create_app
+    def test_mcp_post_without_slash_hits_mcp_app(self, no_auth_client):
+        with patch("mcp_server.proxy.httpx.AsyncClient") as mock_client_cls:
+            resp = no_auth_client.post("/mcp", headers={"accept": "application/json"})
+            # The MCP app is reached directly; no proxy fallback.
+            assert resp.status_code < 500
+            mock_client_cls.assert_not_called()
 
-        app = create_app()
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.get("/mcp")
-        # The MCP app is reached directly; no redirect and no proxy fallback.
-        assert resp.status_code != 404
-        assert "location" not in resp.headers
-        mock_client_cls.assert_not_called()
+    def test_mcp_with_slash_hits_mcp_app(self, no_auth_client):
+        with patch("mcp_server.proxy.httpx.AsyncClient") as mock_client_cls:
+            resp = no_auth_client.get("/mcp/")
+            # The MCP app is reached (it does not fall through to the proxy).
+            assert resp.status_code < 500
+            assert "location" not in resp.headers
+            mock_client_cls.assert_not_called()
 
-    @patch.dict("os.environ", {}, clear=True)
-    @patch("mcp_server.proxy.httpx.AsyncClient")
-    def test_mcp_post_without_slash_hits_mcp_app(self, mock_client_cls):
-        from mcp_server.app import create_app
+    def test_mcp_query_string_reaches_mcp_app(self, no_auth_client):
+        with patch("mcp_server.proxy.httpx.AsyncClient") as mock_client_cls:
+            resp = no_auth_client.get("/mcp?foo=1")
+            # Query string is preserved and the request reaches the MCP app.
+            assert resp.status_code < 500
+            assert "location" not in resp.headers
+            mock_client_cls.assert_not_called()
 
-        app = create_app()
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/mcp", headers={"accept": "application/json"})
-        # The MCP app is reached directly; no proxy fallback.
-        assert resp.status_code != 404
-        mock_client_cls.assert_not_called()
-
-    @patch.dict("os.environ", {}, clear=True)
-    @patch("mcp_server.proxy.httpx.AsyncClient")
-    def test_mcp_with_slash_hits_mcp_app(self, mock_client_cls):
-        from mcp_server.app import create_app
-
-        app = create_app()
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.get("/mcp/")
-        # The MCP app is reached (it does not fall through to the proxy).
-        assert resp.status_code != 404
-        assert "location" not in resp.headers
-        mock_client_cls.assert_not_called()
-
-    @patch.dict("os.environ", {}, clear=True)
-    @patch("mcp_server.proxy.httpx.AsyncClient")
-    def test_mcp_query_string_reaches_mcp_app(self, mock_client_cls):
-        from mcp_server.app import create_app
-
-        app = create_app()
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.get("/mcp?foo=1")
-        # Query string is preserved and the request reaches the MCP app.
-        assert resp.status_code != 404
-        assert "location" not in resp.headers
-        mock_client_cls.assert_not_called()
-
-    @patch.dict("os.environ", {}, clear=True)
     @patch("mcp_server.proxy.httpx.AsyncClient")
     def test_proxy_route_forwards(self, mock_client_cls):
         mock_client_cls.return_value = _make_proxy_mock()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,14 +29,29 @@ class TestAppNoAuth:
         assert resp.status_code != 404
 
     @patch.dict("os.environ", {}, clear=True)
-    def test_mcp_without_slash_redirects(self):
+    @patch("mcp_server.proxy.httpx.AsyncClient")
+    def test_mcp_without_slash_hits_mcp_app(self, mock_client_cls):
         from mcp_server.app import create_app
 
         app = create_app()
         client = TestClient(app, raise_server_exceptions=False)
-        resp = client.get("/mcp", follow_redirects=False)
-        assert resp.status_code == 307
-        assert resp.headers["location"] == "/mcp/"
+        resp = client.get("/mcp")
+        # The MCP app is reached directly; no redirect and no proxy fallback.
+        assert resp.status_code != 404
+        assert "location" not in resp.headers
+        mock_client_cls.assert_not_called()
+
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("mcp_server.proxy.httpx.AsyncClient")
+    def test_mcp_post_without_slash_hits_mcp_app(self, mock_client_cls):
+        from mcp_server.app import create_app
+
+        app = create_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/mcp", headers={"accept": "application/json"})
+        # The MCP app is reached directly; no proxy fallback.
+        assert resp.status_code != 404
+        mock_client_cls.assert_not_called()
 
     @patch.dict("os.environ", {}, clear=True)
     @patch("mcp_server.proxy.httpx.AsyncClient")
@@ -52,14 +67,17 @@ class TestAppNoAuth:
         mock_client_cls.assert_not_called()
 
     @patch.dict("os.environ", {}, clear=True)
-    def test_mcp_redirect_preserves_query_string(self):
+    @patch("mcp_server.proxy.httpx.AsyncClient")
+    def test_mcp_query_string_reaches_mcp_app(self, mock_client_cls):
         from mcp_server.app import create_app
 
         app = create_app()
         client = TestClient(app, raise_server_exceptions=False)
-        resp = client.get("/mcp?foo=1", follow_redirects=False)
-        assert resp.status_code == 307
-        assert resp.headers["location"] == "/mcp/?foo=1"
+        resp = client.get("/mcp?foo=1")
+        # Query string is preserved and the request reaches the MCP app.
+        assert resp.status_code != 404
+        assert "location" not in resp.headers
+        mock_client_cls.assert_not_called()
 
     @patch.dict("os.environ", {}, clear=True)
     @patch("mcp_server.proxy.httpx.AsyncClient")

--- a/uv.lock
+++ b/uv.lock
@@ -650,7 +650,7 @@ wheels = [
 
 [[package]]
 name = "searxng-http-mcp"
-version = "1.1.5"
+version = "1.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Problem

The previous `/mcp` redirect fix only handled `GET`/`HEAD`, so MCP clients that `POST` to `/mcp` still fell through to the SearXNG reverse proxy and received a 404 HTML page.

## Change

Replace the redirect route with a native ASGI wrapper (`_mcp_app`) that:
- Keeps the existing `Mount("/mcp", ...)` for `/mcp/` requests.
- Adds `Route("/mcp", ...)` accepting `GET`, `POST`, `HEAD` so `/mcp` is served directly.
- Normalizes both the empty stripped path (`/mcp`) and `/mcp/` to `/` so the inner MCP app route matches.

This makes `/mcp` and `/mcp/` behave identically for all MCP HTTP methods without relying on client redirect support.

## Version

Also bumps release version to `1.1.6`.

## Verification

- Added/updated tests covering `GET`, `POST`, and query-string access to `/mcp`.
- All 64 tests pass, coverage 93%+.
