### PR TITLE
fix(entrypoint): eliminate startup race between SearXNG boot and JSON-format patch

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -3,22 +3,42 @@ set -e
 
 export PATH="/usr/local/searxng/.venv/bin:${PATH}"
 
-# Ensure JSON format is enabled in SearXNG settings.
-ensure_json_format() {
-    settings="/etc/searxng/settings.yml"
-    i=0
-    while [ ! -f "$settings" ] && [ "$i" -lt 10 ]; do
-        sleep 1
-        i=$((i + 1))
-    done
-    python -m mcp_server.patch_settings "$settings"
-}
+# Fix for a startup-order bug in the stock image: `searx/__init__.py` calls
+# `init_settings()` exactly once, at module import time, with no reload
+# mechanism (no SIGHUP handler, no reload endpoint - confirmed by reading
+# the source). The stock custom-entrypoint.sh starts SearXNG (entrypoint.sh
+# -> exec granian -> imports searx -> settings loaded into memory) in the
+# background, then races a *separate* python process (patch_settings.py) to
+# edit settings.yml afterward. Whichever finishes importing/patching first
+# wins; on a loaded machine granian's already-warm process reliably beats a
+# freshly spawned python interpreter, so the patch lands on disk but is
+# never read by the running process - every `format=json` request then
+# gets `flask.abort(403)` in webapp.py's /search route, permanently, for
+# that container's lifetime.
+#
+# Fix: do the same settings.yml creation + patch synchronously, before
+# SearXNG's own entrypoint ever runs, so there's no window to lose. This
+# keeps everything generated fresh on every container start (template copy,
+# random secret_key, JSON-format patch) - nothing is baked into the image.
 
-# Start SearXNG in the background, redirect all output to stderr
+TEMPLATE_SETTINGS="/usr/local/searxng/settings.template.yml"
+TARGET_SETTINGS="${__SEARXNG_CONFIG_PATH}/settings.yml"
+
+if [ ! -f "$TARGET_SETTINGS" ]; then
+    echo "\"$TARGET_SETTINGS\" does not exist, creating from template..." >&2
+    cp -pfT "$TEMPLATE_SETTINGS" "$TARGET_SETTINGS"
+    # Matches entrypoint.sh's own secret_key randomization so this stays
+    # equivalent to stock behavior, not just the JSON-format piece.
+    sed -i "s/ultrasecretkey/$(head -c 24 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9')/g" "$TARGET_SETTINGS"
+fi
+
+# Patch settings to enable JSON format. Guaranteed to complete before
+# SearXNG's own process starts importing settings.yml, below.
+python -m mcp_server.patch_settings "$TARGET_SETTINGS" >&2
+
+# Start SearXNG. Its own entrypoint.sh will see settings.yml already
+# exists and skip straight to `exec granian` - no race, no double work.
 /usr/local/searxng/entrypoint.sh >&2 2>&1 &
-
-# Patch settings to enable JSON format
-ensure_json_format >&2
 
 # Wait for SearXNG to be ready (all logs to stderr)
 echo "Waiting for SearXNG to start..." >&2


### PR DESCRIPTION
## Bug

Every `/search?format=json` request returns `403 Forbidden`, permanently,
for the lifetime of the container — reproducible with a plain `docker run`,
no restart loop or special config needed.

## Root cause

`searx/__init__.py`'s `init_settings()` loads `settings.yml` exactly once,
at module import time. There's no reload mechanism (no SIGHUP handler, no
admin endpoint — confirmed by reading the source).

The current `scripts/entrypoint.sh` starts SearXNG in the background and
*races* a separate `patch_settings.py` process against it to add `"json"`
to `search.formats`:

```sh
/usr/local/searxng/entrypoint.sh >&2 2>&1 &   # boots SearXNG, imports settings.yml
ensure_json_format >&2                          # patches settings.yml on disk
