### PR TITLE
chore(release): bump version to 1.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "searxng-http-mcp",
       "source": "./plugins/local",
       "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "local", "docker"]
     },
@@ -17,7 +17,7 @@
       "name": "searxng-http-mcp-remote",
       "source": "./plugins/remote",
       "description": "SearXNG MCP server (remote HTTP) — connect to a deployed instance",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "remote", "http"]
     },
@@ -25,7 +25,7 @@
       "name": "searxng-http-mcp-standalone",
       "source": "./plugins/standalone",
       "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "uvx", "standalone"]
     }

--- a/plugins/local/.claude-plugin/plugin.json
+++ b/plugins/local/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/local/.codex-plugin/plugin.json
+++ b/plugins/local/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/local/.plugin/plugin.json
+++ b/plugins/local/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.claude-plugin/plugin.json
+++ b/plugins/remote/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.codex-plugin/plugin.json
+++ b/plugins/remote/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.plugin/plugin.json
+++ b/plugins/remote/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.claude-plugin/plugin.json
+++ b/plugins/standalone/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.codex-plugin/plugin.json
+++ b/plugins/standalone/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.plugin/plugin.json
+++ b/plugins/standalone/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["mcp_server"]
 
 [project]
 name = "searxng-http-mcp"
-version = "1.2.0"
+version = "1.2.1"
 description = "SearXNG metasearch engine MCP server"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/whw23/searxng_http_mcp",
     "source": "github"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "packages": [
     {
       "registryType": "pypi",

--- a/uv.lock
+++ b/uv.lock
@@ -680,7 +680,7 @@ wheels = [
 
 [[package]]
 name = "searxng-http-mcp"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

版本 bump 到 `1.2.1`（补丁版本），包含 PR #199 的 entrypoint 修复（`/search?format=json` 403 bug）。

- 版本 `1.1.6` → 已发布 v1.2.0 → 本次 `1.2.0` → `1.2.1`
- `scripts/sync-version.sh` 同步所有 plugin/config 文件 + uv.lock

合并后 dev → main 发布 v1.2.1（build.yml 自动处理 Docker/PyPI/Release）