### PR TITLE
Release v1.2.1: entrypoint fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "searxng-http-mcp",
       "source": "./plugins/local",
       "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "local", "docker"]
     },
@@ -17,7 +17,7 @@
       "name": "searxng-http-mcp-remote",
       "source": "./plugins/remote",
       "description": "SearXNG MCP server (remote HTTP) — connect to a deployed instance",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "remote", "http"]
     },
@@ -25,7 +25,7 @@
       "name": "searxng-http-mcp-standalone",
       "source": "./plugins/standalone",
       "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "keywords": ["search", "searxng", "web-search", "mcp", "uvx", "standalone"]
     }

--- a/plugins/local/.claude-plugin/plugin.json
+++ b/plugins/local/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/local/.codex-plugin/plugin.json
+++ b/plugins/local/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/local/.plugin/plugin.json
+++ b/plugins/local/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (local Docker stdio) — zero-config, self-contained",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.claude-plugin/plugin.json
+++ b/plugins/remote/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.codex-plugin/plugin.json
+++ b/plugins/remote/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/remote/.plugin/plugin.json
+++ b/plugins/remote/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-remote",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (remote HTTP mode) — connect to a deployed SearXNG instance",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.claude-plugin/plugin.json
+++ b/plugins/standalone/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.codex-plugin/plugin.json
+++ b/plugins/standalone/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/plugins/standalone/.plugin/plugin.json
+++ b/plugins/standalone/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "searxng-http-mcp-standalone",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SearXNG MCP server (uvx standalone) — no Docker, connect to your own SearXNG",
   "author": {
     "name": "whw23"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["mcp_server"]
 
 [project]
 name = "searxng-http-mcp"
-version = "1.2.0"
+version = "1.2.1"
 description = "SearXNG metasearch engine MCP server"
 readme = "README.md"
 license = "MIT"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -3,22 +3,42 @@ set -e
 
 export PATH="/usr/local/searxng/.venv/bin:${PATH}"
 
-# Ensure JSON format is enabled in SearXNG settings.
-ensure_json_format() {
-    settings="/etc/searxng/settings.yml"
-    i=0
-    while [ ! -f "$settings" ] && [ "$i" -lt 10 ]; do
-        sleep 1
-        i=$((i + 1))
-    done
-    python -m mcp_server.patch_settings "$settings"
-}
+# Fix for a startup-order bug in the stock image: `searx/__init__.py` calls
+# `init_settings()` exactly once, at module import time, with no reload
+# mechanism (no SIGHUP handler, no reload endpoint - confirmed by reading
+# the source). The stock custom-entrypoint.sh starts SearXNG (entrypoint.sh
+# -> exec granian -> imports searx -> settings loaded into memory) in the
+# background, then races a *separate* python process (patch_settings.py) to
+# edit settings.yml afterward. Whichever finishes importing/patching first
+# wins; on a loaded machine granian's already-warm process reliably beats a
+# freshly spawned python interpreter, so the patch lands on disk but is
+# never read by the running process - every `format=json` request then
+# gets `flask.abort(403)` in webapp.py's /search route, permanently, for
+# that container's lifetime.
+#
+# Fix: do the same settings.yml creation + patch synchronously, before
+# SearXNG's own entrypoint ever runs, so there's no window to lose. This
+# keeps everything generated fresh on every container start (template copy,
+# random secret_key, JSON-format patch) - nothing is baked into the image.
 
-# Start SearXNG in the background, redirect all output to stderr
+TEMPLATE_SETTINGS="/usr/local/searxng/settings.template.yml"
+TARGET_SETTINGS="${__SEARXNG_CONFIG_PATH}/settings.yml"
+
+if [ ! -f "$TARGET_SETTINGS" ]; then
+    echo "\"$TARGET_SETTINGS\" does not exist, creating from template..." >&2
+    cp -pfT "$TEMPLATE_SETTINGS" "$TARGET_SETTINGS"
+    # Matches entrypoint.sh's own secret_key randomization so this stays
+    # equivalent to stock behavior, not just the JSON-format piece.
+    sed -i "s/ultrasecretkey/$(head -c 24 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9')/g" "$TARGET_SETTINGS"
+fi
+
+# Patch settings to enable JSON format. Guaranteed to complete before
+# SearXNG's own process starts importing settings.yml, below.
+python -m mcp_server.patch_settings "$TARGET_SETTINGS" >&2
+
+# Start SearXNG. Its own entrypoint.sh will see settings.yml already
+# exists and skip straight to `exec granian` - no race, no double work.
 /usr/local/searxng/entrypoint.sh >&2 2>&1 &
-
-# Patch settings to enable JSON format
-ensure_json_format >&2
 
 # Wait for SearXNG to be ready (all logs to stderr)
 echo "Waiting for SearXNG to start..." >&2

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/whw23/searxng_http_mcp",
     "source": "github"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "packages": [
     {
       "registryType": "pypi",

--- a/uv.lock
+++ b/uv.lock
@@ -680,7 +680,7 @@ wheels = [
 
 [[package]]
 name = "searxng-http-mcp"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Release v1.2.1

将 dev 合并到 main 发布 v1.2.1。

### 变更（相对 v1.2.0）

- **entrypoint 启动竞态修复** (PR #199)：`/search?format=json` 403 修复——在 SearXNG 启动前同步 patch settings.yml
- 版本 bump `1.2.0` → `1.2.1`

### 自动发布

merge 后 build.yml 自动：构建 Docker → 发布 PyPI → 创建 GitHub Release v1.2.1