### PR TITLE
docs(readme): fix agent MCP connection configs, add ZCode/Kilo Code/Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,25 @@ Use this to discover what engines are available before calling `search` with spe
 
 ## 🔌 Client Configuration
 
+Clients that use the standard `mcpServers` JSON structure — **Claude Desktop**, **Claude Code**, **Cursor**, **Windsurf**, **Cline** — share this **server mode** (remote HTTP) example; only the config file location differs:
+
+```json
+{
+  "mcpServers": {
+    "searxng": {
+      "type": "http",
+      "url": "http://YOUR_HOST:YOUR_PORT/mcp/",
+      "headers": {
+        "x-api-key": "your-secret-key"
+      }
+    }
+  }
+}
+```
+
+> [!NOTE]
+> Field-name differences: **ZCode** uses `mcp.servers`; **Kilo Code** uses a top-level `mcp` key with `"type": "remote"`; **Windsurf** uses `serverUrl` instead of `url`; **VS Code Copilot** uses a top-level `servers` key; **OpenCode** nests under `mcp` with `"type": "remote"`; **Codex** and **Hermes** use `mcp_servers` (TOML/YAML). For **Claude Code**, `"type": "http"` is **required** — without it the entry is read as a stdio server and skipped. For **Cline**, set `"type": "streamableHttp"` on remote HTTP servers.
+
 <details>
 <summary><img src="assets/icons/claude.svg" height="16" alt="Claude"> <b>Claude Desktop</b></summary>
 
@@ -375,10 +394,27 @@ Use this to discover what engines are available before calling `search` with spe
 <details>
 <summary><img src="assets/icons/claude.svg" height="16" alt="Claude"> <b>Claude Code</b></summary>
 
-**Server mode**:
+**Server mode (CLI)**:
 
 ```bash
-claude mcp add --transport http --header "x-api-key: your-secret-key" searxng http://YOUR_HOST:YOUR_PORT/mcp/
+claude mcp add --transport http searxng http://YOUR_HOST:YOUR_PORT/mcp/ \
+  --header "x-api-key: your-secret-key"
+```
+
+**Server mode (JSON)** — the same `mcpServers` structure works in a **team-shared** project `.mcp.json` or a **user-wide** global `~/.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "searxng": {
+      "type": "http",
+      "url": "http://YOUR_HOST:YOUR_PORT/mcp/",
+      "headers": {
+        "x-api-key": "your-secret-key"
+      }
+    }
+  }
+}
 ```
 
 **Local mode**:
@@ -579,6 +615,7 @@ Configure via Cline's MCP settings panel in VS Code (`Cline > MCP Servers > Add`
 {
   "mcpServers": {
     "searxng": {
+      "type": "streamableHttp",
       "url": "http://YOUR_HOST:YOUR_PORT/mcp/",
       "headers": {
         "x-api-key": "your-secret-key"
@@ -697,6 +734,168 @@ mcp_servers:
 
 </details>
 
+<details>
+<summary>🟦 <b>ZCode</b> (Zhipu AI · GLM)</summary>
+
+**Server mode** — edit `~/.zcode/cli/config.json` (user-wide) or `.zcode/config.json` (project):
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "searxng": {
+        "type": "http",
+        "url": "http://YOUR_HOST:YOUR_PORT/mcp/",
+        "headers": {
+          "x-api-key": "your-secret-key"
+        }
+      }
+    }
+  }
+}
+```
+
+**Local mode**:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "searxng": {
+        "command": "docker",
+        "args": ["run", "--rm", "-i", "--memory=512m", "--cpus=1", "ghcr.io/whw23/searxng-http-mcp:latest", "--stdio"]
+      }
+    }
+  }
+}
+```
+
+**uvx mode**:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "searxng": {
+        "command": "uvx",
+        "args": ["searxng-http-mcp"],
+        "env": { "SEARXNG_URL": "http://YOUR_SEARXNG_HOST:YOUR_SEARXNG_PORT" }
+      }
+    }
+  }
+}
+```
+
+ZCode also accepts the standard `mcpServers` structure (e.g. in `.agents/mcp.json`). Alternatively, add servers via `Settings → MCP Servers → New MCP Server`.
+
+</details>
+
+<details>
+<summary>⚡ <b>Kilo Code</b></summary>
+
+**Server mode** — edit `~/.config/kilo/kilo.jsonc` (global) or `.kilo/kilo.jsonc` (project):
+
+```json
+{
+  "mcp": {
+    "searxng": {
+      "type": "remote",
+      "url": "http://YOUR_HOST:YOUR_PORT/mcp/",
+      "headers": {
+        "x-api-key": "your-secret-key"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+**Local mode**:
+
+```json
+{
+  "mcp": {
+    "searxng": {
+      "type": "local",
+      "command": ["docker", "run", "--rm", "-i", "--memory=512m", "--cpus=1", "ghcr.io/whw23/searxng-http-mcp:latest", "--stdio"],
+      "enabled": true
+    }
+  }
+}
+```
+
+**uvx mode**:
+
+```json
+{
+  "mcp": {
+    "searxng": {
+      "type": "local",
+      "command": ["uvx", "searxng-http-mcp"],
+      "environment": { "SEARXNG_URL": "http://YOUR_SEARXNG_HOST:YOUR_SEARXNG_PORT" },
+      "enabled": true
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>🥧 <b>Pi</b></summary>
+
+Install the MCP adapter once, then add a standard `mcpServers` block — e.g. in `~/.pi/agent/mcp.json` (all projects) or `.pi/mcp.json` (project):
+
+```bash
+pi install npm:pi-mcp-adapter
+```
+
+Restart Pi after installing.
+
+**Server mode**:
+
+```json
+{
+  "mcpServers": {
+    "searxng": {
+      "url": "http://YOUR_HOST:YOUR_PORT/mcp/",
+      "headers": {
+        "x-api-key": "your-secret-key"
+      }
+    }
+  }
+}
+```
+
+**Local mode**:
+
+```json
+{
+  "mcpServers": {
+    "searxng": {
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "--memory=512m", "--cpus=1", "ghcr.io/whw23/searxng-http-mcp:latest", "--stdio"]
+    }
+  }
+}
+```
+
+**uvx mode**:
+
+```json
+{
+  "mcpServers": {
+    "searxng": {
+      "command": "uvx",
+      "args": ["searxng-http-mcp"],
+      "env": { "SEARXNG_URL": "http://YOUR_SEARXNG_HOST:YOUR_SEARXNG_PORT" }
+    }
+  }
+}
+```
+
+</details>
+
 ---
 
 ## 🧩 AI Coding Agent Plugin
@@ -725,7 +924,7 @@ All plugins include:
 <br>
 
 ```bash
-/plugin install searxng-http-mcp@searxng-http-mcp-standalone
+/plugin install searxng-http-mcp-standalone@searxng-http-mcp
 ```
 
 Runs via `uvx`. Requires Python 3.14+ and an existing SearXNG instance. Set `SEARXNG_URL` in `~/.claude/settings.json`:
@@ -759,7 +958,7 @@ Runs SearXNG in a local Docker container via stdio. Requires Docker installed.
 <br>
 
 ```bash
-/plugin install searxng-http-mcp@searxng-http-mcp-remote
+/plugin install searxng-http-mcp-remote@searxng-http-mcp
 ```
 
 Connects to a deployed SearXNG MCP server. Requires env vars `SEARXNG_MCP_URL` and `SEARXNG_API_KEY`.

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Use this to discover what engines are available before calling `search` with spe
 
 ## 🔌 Client Configuration
 
-Clients that use the standard `mcpServers` JSON structure — **Claude Desktop**, **Claude Code**, **Cursor**, **Windsurf**, **Cline** — share this **server mode** (remote HTTP) example; only the config file location differs:
+The following is a **baseline** server-mode (remote HTTP) example using the standard `mcpServers` JSON structure. Many clients accept this structure, but field names and required `type` values differ — see the NOTE below and adjust for your client:
 
 ```json
 {

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -325,6 +325,25 @@ SEARXNG_URL=http://YOUR_SEARXNG_HOST:YOUR_SEARXNG_PORT uvx searxng-http-mcp
 
 ## 🔌 客户端配置
 
+使用标准 `mcpServers` JSON 结构的客户端 —— **Claude Desktop**、**Claude Code**、**Cursor**、**Windsurf**、**Cline** —— 共享以下**服务器模式**（远程 HTTP）示例；区别仅在配置文件位置：
+
+```json
+{
+  "mcpServers": {
+    "searxng": {
+      "type": "http",
+      "url": "http://YOUR_HOST:YOUR_PORT/mcp/",
+      "headers": {
+        "x-api-key": "your-secret-key"
+      }
+    }
+  }
+}
+```
+
+> [!NOTE]
+> 字段名差异：**ZCode** 用 `mcp.servers` 键；**Kilo Code** 用顶层 `mcp` 键且 `"type": "remote"`；**Windsurf** 用 `serverUrl` 而非 `url`；**VS Code Copilot** 用顶层 `servers` 键；**OpenCode** 嵌套在 `mcp` 下且用 `"type": "remote"`；**Codex** 和 **Hermes** 使用 `mcp_servers`（TOML/YAML）。对 **Claude Code** 而言，`"type": "http"` 是**必需的** —— 缺少该字段会被当作 stdio 服务器并跳过。对 **Cline** 而言，远程 HTTP 服务器需设置 `"type": "streamableHttp"`。
+
 <details>
 <summary><img src="assets/icons/claude.svg" height="16" alt="Claude"> <b>Claude Desktop</b></summary>
 
@@ -377,10 +396,27 @@ SEARXNG_URL=http://YOUR_SEARXNG_HOST:YOUR_SEARXNG_PORT uvx searxng-http-mcp
 <details>
 <summary><img src="assets/icons/claude.svg" height="16" alt="Claude"> <b>Claude Code</b></summary>
 
-**服务器模式**：
+**服务器模式（命令行）**：
 
 ```bash
-claude mcp add --transport http --header "x-api-key: your-secret-key" searxng http://YOUR_HOST:YOUR_PORT/mcp/
+claude mcp add --transport http searxng http://YOUR_HOST:YOUR_PORT/mcp/ \
+  --header "x-api-key: your-secret-key"
+```
+
+**服务器模式（JSON）** —— 同样的 `mcpServers` 结构既可用于**团队共享**的项目级 `.mcp.json`，也可用于**全局生效**的用户级 `~/.claude.json`：
+
+```json
+{
+  "mcpServers": {
+    "searxng": {
+      "type": "http",
+      "url": "http://YOUR_HOST:YOUR_PORT/mcp/",
+      "headers": {
+        "x-api-key": "your-secret-key"
+      }
+    }
+  }
+}
 ```
 
 **本地模式**：
@@ -584,6 +620,7 @@ args = ["searxng-http-mcp"]
 {
   "mcpServers": {
     "searxng": {
+      "type": "streamableHttp",
       "url": "http://YOUR_HOST:YOUR_PORT/mcp/",
       "headers": {
         "x-api-key": "your-secret-key"
@@ -704,6 +741,174 @@ mcp_servers:
 
 </details>
 
+<details>
+<summary>🟦 <b>ZCode</b>（智谱 AI · GLM）</summary>
+
+**服务器模式** —— 编辑 `~/.zcode/cli/config.json`（全局）或 `.zcode/config.json`（项目）：
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "searxng": {
+        "type": "http",
+        "url": "http://YOUR_HOST:YOUR_PORT/mcp/",
+        "headers": {
+          "x-api-key": "your-secret-key"
+        }
+      }
+    }
+  }
+}
+```
+
+**本地模式**：
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "searxng": {
+        "command": "docker",
+        "args": ["run", "--rm", "-i", "--memory=512m", "--cpus=1", "ghcr.io/whw23/searxng-http-mcp:latest", "--stdio"]
+      }
+    }
+  }
+}
+```
+
+**uvx 模式**：
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "searxng": {
+        "command": "uvx",
+        "args": ["searxng-http-mcp"],
+        "env": {
+          "SEARXNG_URL": "http://YOUR_SEARXNG_HOST:YOUR_SEARXNG_PORT"
+        }
+      }
+    }
+  }
+}
+```
+
+ZCode 也接受标准 `mcpServers` 结构（如放在 `.agents/mcp.json`）。也可以通过 `设置 → MCP 服务器 → 新建 MCP 服务器` 添加。
+
+</details>
+
+<details>
+<summary>⚡ <b>Kilo Code</b></summary>
+
+**服务器模式** —— 编辑 `~/.config/kilo/kilo.jsonc`（全局）或 `.kilo/kilo.jsonc`（项目）：
+
+```json
+{
+  "mcp": {
+    "searxng": {
+      "type": "remote",
+      "url": "http://YOUR_HOST:YOUR_PORT/mcp/",
+      "headers": {
+        "x-api-key": "your-secret-key"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+**本地模式**：
+
+```json
+{
+  "mcp": {
+    "searxng": {
+      "type": "local",
+      "command": ["docker", "run", "--rm", "-i", "--memory=512m", "--cpus=1", "ghcr.io/whw23/searxng-http-mcp:latest", "--stdio"],
+      "enabled": true
+    }
+  }
+}
+```
+
+**uvx 模式**：
+
+```json
+{
+  "mcp": {
+    "searxng": {
+      "type": "local",
+      "command": ["uvx", "searxng-http-mcp"],
+      "environment": {
+        "SEARXNG_URL": "http://YOUR_SEARXNG_HOST:YOUR_SEARXNG_PORT"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>🥧 <b>Pi</b></summary>
+
+安装 MCP 适配器一次，然后添加标准 `mcpServers` 配置块 —— 例如 `~/.pi/agent/mcp.json`（所有项目）或 `.pi/mcp.json`（项目）：
+
+```bash
+pi install npm:pi-mcp-adapter
+```
+
+安装后重启 Pi。
+
+**服务器模式**：
+
+```json
+{
+  "mcpServers": {
+    "searxng": {
+      "url": "http://YOUR_HOST:YOUR_PORT/mcp/",
+      "headers": {
+        "x-api-key": "your-secret-key"
+      }
+    }
+  }
+}
+```
+
+**本地模式**：
+
+```json
+{
+  "mcpServers": {
+    "searxng": {
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "--memory=512m", "--cpus=1", "ghcr.io/whw23/searxng-http-mcp:latest", "--stdio"]
+    }
+  }
+}
+```
+
+**uvx 模式**：
+
+```json
+{
+  "mcpServers": {
+    "searxng": {
+      "command": "uvx",
+      "args": ["searxng-http-mcp"],
+      "env": {
+        "SEARXNG_URL": "http://YOUR_SEARXNG_HOST:YOUR_SEARXNG_PORT"
+      }
+    }
+  }
+}
+```
+
+</details>
+
 ---
 
 ## 🧩 AI 编程代理插件
@@ -732,7 +937,7 @@ mcp_servers:
 <br>
 
 ```bash
-/plugin install searxng-http-mcp@searxng-http-mcp-standalone
+/plugin install searxng-http-mcp-standalone@searxng-http-mcp
 ```
 
 通过 `uvx` 运行。需要 Python 3.14+ 和已有的 SearXNG 实例。在 `~/.claude/settings.json` 中设置 `SEARXNG_URL`：
@@ -766,7 +971,7 @@ mcp_servers:
 <br>
 
 ```bash
-/plugin install searxng-http-mcp@searxng-http-mcp-remote
+/plugin install searxng-http-mcp-remote@searxng-http-mcp
 ```
 
 连接到已部署的 SearXNG MCP 服务器。需要设置环境变量 `SEARXNG_MCP_URL` 和 `SEARXNG_API_KEY`。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -325,7 +325,7 @@ SEARXNG_URL=http://YOUR_SEARXNG_HOST:YOUR_SEARXNG_PORT uvx searxng-http-mcp
 
 ## 🔌 客户端配置
 
-使用标准 `mcpServers` JSON 结构的客户端 —— **Claude Desktop**、**Claude Code**、**Cursor**、**Windsurf**、**Cline** —— 共享以下**服务器模式**（远程 HTTP）示例；区别仅在配置文件位置：
+以下是一个**基准**服务器模式（远程 HTTP）示例，使用标准的 `mcpServers` JSON 结构。多个客户端接受该结构，但字段名和必需的 `type` 值因客户端而异 —— 请根据下方 NOTE 针对你的客户端调整：
 
 ```json
 {


### PR DESCRIPTION
## Summary

修复并补充 README（英文 + 中文）中的 AI agent MCP 连接配置。

## Changes

### Fixes
- **`/plugin install` 命令**：`plugin@marketplace` 结构写反。marketplace 名应为 `searxng-http-mcp`（来自 `.claude-plugin/marketplace.json`），修复 remote / standalone 插件无法安装的问题
- **Cline**：远程 HTTP 服务器需显式设置 `"type": "streamableHttp"`，省略会退化为 legacy SSE 传输
- **Claude Code**：`claude mcp add --transport http` 命令参数顺序对齐官方文档

### Additions
- **Client Configuration** 开头新增跨客户端通用服务器模式示例 + 字段差异说明（NOTE）
- **Claude Code** 部分补充项目级 `.mcp.json` 与全局 `~/.claude.json` 两种 JSON 配置位置
- 新增 3 个主流 agent 的连接配置（服务器/本地/uvx 三种模式）：
  - **ZCode**（智谱 AI · GLM）— `mcp.servers`，`~/.zcode/cli/config.json`
  - **Kilo Code** — 顶层 `mcp` 键 + `type: remote`，`~/.config/kilo/kilo.jsonc`
  - **Pi** — `pi-mcp-adapter` + 标准 `mcpServers`

## Verification
- 所有新增 JSON 块通过 JSON 语法校验
- push 触发的 test.yml CI 通过